### PR TITLE
Add landing page and NACE code finder

### DIFF
--- a/docs/assets/nace-app.jsx
+++ b/docs/assets/nace-app.jsx
@@ -1,0 +1,96 @@
+function NACECodeFinder() {
+  const { useState, useEffect } = React;
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchField, setSearchField] = useState('all');
+  const [secondaryQuery, setSecondaryQuery] = useState('');
+  const [secondaryField, setSecondaryField] = useState('all');
+  const [data, setData] = useState([]);
+  const [filteredData, setFilteredData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const loadData = (retry = 3) => {
+    const url = 'assets/nace_data.json';
+    fetch(url)
+      .then((r) => r.json())
+      .then((d) => { setData(d); setLoading(false); })
+      .catch((err) => {
+        if (retry > 0) {
+          setTimeout(() => loadData(retry - 1), 2000);
+        } else {
+          setError('Error: ' + err.message);
+          setLoading(false);
+        }
+      });
+  };
+
+  useEffect(() => { loadData(); }, []);
+
+  const handleSearch = () => {
+    const filtered = data.filter((item) => {
+      const primaryMatch = searchField === 'all' || (item[searchField] && item[searchField].toString().toLowerCase().includes(searchQuery.toLowerCase()));
+      const secondaryMatch = secondaryField === 'all' || (item[secondaryField] && item[secondaryField].toString().toLowerCase().includes(secondaryQuery.toLowerCase()));
+      return primaryMatch && secondaryMatch;
+    });
+    setFilteredData(filtered);
+  };
+
+  const handleReset = () => {
+    setSearchQuery('');
+    setSecondaryQuery('');
+    setSearchField('all');
+    setSecondaryField('all');
+    setFilteredData([]);
+  };
+
+  if (loading) return React.createElement('div', { style: { padding: '20px', textAlign: 'center' } }, 'Loading data...');
+  if (error) return React.createElement('div', { style: { padding: '20px', textAlign: 'center' } }, error);
+
+  return (
+    React.createElement('div', { style: { padding: '20px', maxWidth: '600px', margin: '0 auto' } },
+      React.createElement('h1', { style: { fontSize: '24px', fontWeight: 'bold', marginBottom: '16px', textAlign: 'center' } }, 'NACE Code Finder'),
+      React.createElement('div', { style: { marginBottom: '16px' } },
+        React.createElement('h3', null, 'Primary Search'),
+        React.createElement('input', { type: 'text', placeholder: 'Primary Search...', value: searchQuery, onChange: (e) => setSearchQuery(e.target.value), style: { width: '100%', padding: '10px', marginBottom: '8px' } }),
+        React.createElement('select', { value: searchField, onChange: (e) => setSearchField(e.target.value), style: { width: '100%', padding: '10px' } },
+          React.createElement('option', { value: 'all' }, 'All Fields'),
+          React.createElement('option', { value: 'CODE' }, 'Code'),
+          React.createElement('option', { value: 'NAME' }, 'Name'),
+          React.createElement('option', { value: 'Includes' }, 'Includes'),
+          React.createElement('option', { value: 'IncludesAlso' }, 'Includes Also'),
+          React.createElement('option', { value: 'Excludes' }, 'Excludes')
+        )
+      ),
+      React.createElement('div', { style: { marginBottom: '16px' } },
+        React.createElement('h3', null, 'Secondary Search (Optional)'),
+        React.createElement('input', { type: 'text', placeholder: 'Secondary Search...', value: secondaryQuery, onChange: (e) => setSecondaryQuery(e.target.value), style: { width: '100%', padding: '10px', marginBottom: '8px' } }),
+        React.createElement('select', { value: secondaryField, onChange: (e) => setSecondaryField(e.target.value), style: { width: '100%', padding: '10px' } },
+          React.createElement('option', { value: 'all' }, 'All Fields'),
+          React.createElement('option', { value: 'CODE' }, 'Code'),
+          React.createElement('option', { value: 'NAME' }, 'Name'),
+          React.createElement('option', { value: 'Includes' }, 'Includes'),
+          React.createElement('option', { value: 'IncludesAlso' }, 'Includes Also'),
+          React.createElement('option', { value: 'Excludes' }, 'Excludes')
+        )
+      ),
+      React.createElement('div', { style: { textAlign: 'center', marginBottom: '16px' } },
+        React.createElement('button', { onClick: handleSearch, style: { padding: '10px 20px', backgroundColor: '#007bff', color: '#fff', border: 'none', borderRadius: '4px', cursor: 'pointer' } }, 'Search'),
+        React.createElement('button', { onClick: handleReset, style: { padding: '10px 20px', backgroundColor: '#6c757d', color: '#fff', border: 'none', borderRadius: '4px', marginLeft: '8px', cursor: 'pointer' } }, 'Reset')
+      ),
+      filteredData.length > 0 ? (
+        filteredData.map((item, idx) => (
+          React.createElement('div', { key: idx, style: { marginBottom: '12px', padding: '12px', backgroundColor: '#f9f9f9', border: '1px solid #ddd', borderRadius: '4px' } },
+            React.createElement('p', null, React.createElement('strong', null, 'Code:'), ' ', item.CODE.toString()),
+            React.createElement('p', null, React.createElement('strong', null, 'Name:'), ' ', item.NAME),
+            React.createElement('p', null, React.createElement('strong', null, 'Includes:'), ' ', item.Includes),
+            item.IncludesAlso ? React.createElement('p', null, React.createElement('strong', null, 'Includes Also:'), ' ', item.IncludesAlso) : null,
+            item.Excludes ? React.createElement('p', null, React.createElement('strong', null, 'Excludes:'), ' ', item.Excludes) : null
+          )
+        ))
+      ) : React.createElement('p', { style: { textAlign: 'center' } }, 'No results found.')
+    )
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(NACECodeFinder));

--- a/docs/assets/nace_data.json
+++ b/docs/assets/nace_data.json
@@ -1,0 +1,23 @@
+[
+  {
+    "CODE": "01.11",
+    "NAME": "Growing of cereals (except rice), leguminous crops and oil seeds",
+    "Includes": "All forms of farmland cropping of cereals, pulses and oilseed plants",
+    "IncludesAlso": "Includes the cultivation of field peas and beans",
+    "Excludes": "Rice cultivation"
+  },
+  {
+    "CODE": "01.21",
+    "NAME": "Growing of grapes",
+    "Includes": "Cultivation of wine or table grapes",
+    "IncludesAlso": "",
+    "Excludes": "Manufacture of wine"
+  },
+  {
+    "CODE": "10.11",
+    "NAME": "Processing and preserving of meat",
+    "Includes": "Operation of slaughterhouses, production of fresh meat",
+    "IncludesAlso": "",
+    "Excludes": "Manufacture of prepared meals"
+  }
+]

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,18 +2,20 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>OECD TPG Viewer</title>
+  <title>Document Tools</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="assets/style.css" />
+  <style>
+    body { text-align: center; }
+    .btn-container { margin-top: 40px; }
+    .app-link { display: inline-block; margin: 10px; padding: 15px 25px; background:#007bff; color:#fff; text-decoration:none; border-radius:4px; }
+  </style>
 </head>
 <body>
-  <div id="root">
-    <h1>OECD TPG Viewer</h1>
-    <input type="text" id="search" placeholder="Search paragraphs..." />
-    <div id="results"></div>
+  <h1>Choose an application</h1>
+  <div class="btn-container">
+    <a class="app-link" href="oecd.html">OECD TPG Viewer</a>
+    <a class="app-link" href="nace.html">NACE Code Finder</a>
   </div>
-
-  <script src="assets/data.js"></script>
-  <script src="assets/index.js"></script>
 </body>
 </html>

--- a/docs/nace.html
+++ b/docs/nace.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>NACE Code Finder</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="assets/style.css" />
+  <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/javascript" src="assets/nace-app.jsx"></script>
+</body>
+</html>

--- a/docs/oecd.html
+++ b/docs/oecd.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>OECD TPG Viewer</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+  <div id="root">
+    <h1>OECD TPG Viewer</h1>
+    <input type="text" id="search" placeholder="Search paragraphs..." />
+    <div id="results"></div>
+  </div>
+
+  <script src="assets/data.js"></script>
+  <script src="assets/index.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rename TPG viewer page to `oecd.html`
- add a new landing page with buttons linking to the two apps
- create React-based NACE code finder page
- add sample NACE data for the lookup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684430f50a3883299bcfb2241c530170