### PR TITLE
Improve NACE finder UX

### DIFF
--- a/docs/assets/nace-app.jsx
+++ b/docs/assets/nace-app.jsx
@@ -27,43 +27,45 @@ function NACECodeFinder() {
 
   useEffect(() => { loadData(); }, []);
 
-  // Function to format text with bullet points and line breaks
+  // Format text with bullet points and line breaks using lists
   const formatText = (text) => {
     if (!text) return null;
-    
+
     const lines = text.split('\n');
-    const elements = [];
-    
-    lines.forEach((line, index) => {
-      if (line.trim() === '') return; // Skip empty lines
-      
-      const trimmedLine = line.trim();
-      
-      // Check if it's a bullet point line
-      if (trimmedLine.startsWith('•') || trimmedLine.startsWith('-')) {
-        elements.push(
-          React.createElement('div', { 
-            key: index, 
-            style: { 
-              marginLeft: '20px', 
-              marginBottom: '2px',
-              display: 'flex',
-              alignItems: 'flex-start'
-            } 
-          },
-            React.createElement('span', { style: { marginRight: '8px', fontWeight: 'bold' } }, '•'),
-            React.createElement('span', null, trimmedLine.replace(/^[•-]\s*/, ''))
+    let listItems = [];
+    const parts = [];
+
+    const flushList = () => {
+      if (listItems.length > 0) {
+        parts.push(
+          React.createElement(
+            'ul',
+            { style: { marginLeft: '20px', marginBottom: '4px' } },
+            listItems.map((li, idx) =>
+              React.createElement('li', { key: `li-${idx}` }, li)
+            )
           )
         );
+        listItems = [];
+      }
+    };
+
+    lines.forEach((line, index) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+
+      if (trimmed.startsWith('•') || trimmed.startsWith('-')) {
+        listItems.push(trimmed.replace(/^[•-]\s*/, ''));
       } else {
-        // Regular line
-        elements.push(
-          React.createElement('div', { key: index, style: { marginBottom: '4px' } }, trimmedLine)
+        flushList();
+        parts.push(
+          React.createElement('div', { key: `p-${index}`, style: { marginBottom: '4px' } }, trimmed)
         );
       }
     });
-    
-    return React.createElement('div', null, ...elements);
+
+    flushList();
+    return React.createElement('div', null, ...parts);
   };
 
   const handleSearch = () => {
@@ -88,10 +90,10 @@ function NACECodeFinder() {
 
   return (
     React.createElement('div', { style: { padding: '20px', maxWidth: '800px', margin: '0 auto' } },
-      React.createElement('h1', { style: { fontSize: '24px', fontWeight: 'bold', marginBottom: '16px', textAlign: 'center' } }, 'NACE Code Finder'),
+      React.createElement('h1', { style: { fontSize: '24px', fontWeight: 'bold', marginBottom: '16px', textAlign: 'center' } }, 'NACE Rev. 2.1 Code Finder'),
       React.createElement('div', { style: { marginBottom: '16px' } },
         React.createElement('h3', null, 'Primary Search'),
-        React.createElement('input', { type: 'text', placeholder: 'Primary Search...', value: searchQuery, onChange: (e) => setSearchQuery(e.target.value), style: { width: '100%', padding: '10px', marginBottom: '8px' } }),
+        React.createElement('input', { type: 'text', placeholder: 'Primary Search...', value: searchQuery, onChange: (e) => setSearchQuery(e.target.value), onKeyDown: (e) => { if (e.key === 'Enter') handleSearch(); }, style: { width: '100%', padding: '10px', marginBottom: '8px' } }),
         React.createElement('select', { value: searchField, onChange: (e) => setSearchField(e.target.value), style: { width: '100%', padding: '10px' } },
           React.createElement('option', { value: 'all' }, 'All Fields'),
           React.createElement('option', { value: 'CODE' }, 'Code'),
@@ -103,7 +105,7 @@ function NACECodeFinder() {
       ),
       React.createElement('div', { style: { marginBottom: '16px' } },
         React.createElement('h3', null, 'Secondary Search (Optional)'),
-        React.createElement('input', { type: 'text', placeholder: 'Secondary Search...', value: secondaryQuery, onChange: (e) => setSecondaryQuery(e.target.value), style: { width: '100%', padding: '10px', marginBottom: '8px' } }),
+        React.createElement('input', { type: 'text', placeholder: 'Secondary Search...', value: secondaryQuery, onChange: (e) => setSecondaryQuery(e.target.value), onKeyDown: (e) => { if (e.key === 'Enter') handleSearch(); }, style: { width: '100%', padding: '10px', marginBottom: '8px' } }),
         React.createElement('select', { value: secondaryField, onChange: (e) => setSecondaryField(e.target.value), style: { width: '100%', padding: '10px' } },
           React.createElement('option', { value: 'all' }, 'All Fields'),
           React.createElement('option', { value: 'CODE' }, 'Code'),

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -32,3 +32,14 @@ input {
   font-style: italic;
   margin-top: 5px;
 }
+
+/* Reusable button link style */
+.app-link {
+  display: inline-block;
+  margin: 10px;
+  padding: 15px 25px;
+  background: #007bff;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,6 @@
   <style>
     body { text-align: center; }
     .btn-container { margin-top: 40px; }
-    .app-link { display: inline-block; margin: 10px; padding: 15px 25px; background:#007bff; color:#fff; text-decoration:none; border-radius:4px; }
   </style>
 </head>
 <body>

--- a/docs/nace.html
+++ b/docs/nace.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <div style="text-align:center;margin-bottom:20px;">
-    <a href="index.html" style="text-decoration:none;color:#007bff;">Home</a>
+    <a class="app-link" href="index.html">Home</a>
   </div>
   <div id="root"></div>
   <script type="text/javascript" src="assets/nace-app.jsx"></script>

--- a/docs/oecd.html
+++ b/docs/oecd.html
@@ -9,7 +9,7 @@
 <body>
   <div id="root" style="max-width:600px;margin:0 auto;padding:20px;">
     <div style="text-align:center;margin-bottom:20px;">
-      <a href="index.html" style="text-decoration:none;color:#007bff;">Home</a>
+      <a class="app-link" href="index.html">Home</a>
     </div>
     <h1 style="text-align:center;">OECD TPG Viewer</h1>
     <input type="text" id="search" placeholder="Search paragraphs..." />


### PR DESCRIPTION
## Summary
- add shared `.app-link` styling in CSS and remove inline styles
- style Home link buttons consistently
- show "NACE Rev. 2.1 Code Finder" heading
- trigger search on `Enter`
- format bullet text using lists for clarity

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68443689b79c8329bb2c264a3805b1ed