### PR TITLE
Add Sankey diagram generator

### DIFF
--- a/docs/assets/sankey/sankey.js
+++ b/docs/assets/sankey/sankey.js
@@ -1,0 +1,155 @@
+// JS for Sankey Diagram Generator
+// Handles parsing input, rendering the chart, exporting data and image
+
+document.addEventListener('DOMContentLoaded', function () {
+  const textarea = document.getElementById('data-input');
+  const renderBtn = document.getElementById('render-btn');
+  const dropZone = document.getElementById('drop-zone');
+  const errorBox = document.getElementById('error');
+  const nodeColorInput = document.getElementById('nodeColor');
+  const linkColorInput = document.getElementById('linkColor');
+  const fontSizeInput = document.getElementById('fontSize');
+  const exportCsvBtn = document.getElementById('export-csv');
+  const exportJsonBtn = document.getElementById('export-json');
+  const exportPngBtn = document.getElementById('export-png');
+  const chartDiv = document.getElementById('chart');
+
+  let chart;
+  let chartData = [];
+
+  // sample data shown on load
+  const defaultData = [
+    { source: 'A', target: 'B', value: 5 },
+    { source: 'A', target: 'C', value: 3 },
+    { source: 'B', target: 'D', value: 2 },
+    { source: 'C', target: 'D', value: 6 }
+  ];
+
+  // helpers
+  const toCSV = (data) => data.map(d => `${d.source},${d.target},${d.value}`).join('\n');
+
+  const showError = (msg) => { errorBox.textContent = msg; };
+  const clearError = () => { errorBox.textContent = ''; };
+
+  // parse input as JSON or CSV
+  function parseInput(text) {
+    text = text.trim();
+    if (!text) return { data: [] };
+    try {
+      const obj = JSON.parse(text);
+      if (Array.isArray(obj)) return { data: obj };
+      return { error: 'JSON must be an array of objects' };
+    } catch (e) {
+      // try CSV
+      const lines = text.split(/\r?\n/).filter(Boolean);
+      const arr = [];
+      for (const line of lines) {
+        const parts = line.split(',');
+        if (parts.length !== 3) return { error: 'Invalid CSV format' };
+        const value = parseFloat(parts[2]);
+        if (isNaN(value)) return { error: 'CSV values must be numbers' };
+        arr.push({ source: parts[0].trim(), target: parts[1].trim(), value });
+      }
+      return { data: arr };
+    }
+  }
+
+  // check that for intermediate nodes inputs equal outputs
+  function validateData(data) {
+    const map = {};
+    data.forEach(({ source, target, value }) => {
+      map[source] = map[source] || { in: 0, out: 0 };
+      map[source].out += value;
+      map[target] = map[target] || { in: 0, out: 0 };
+      map[target].in += value;
+    });
+    const issues = Object.keys(map).filter(k => map[k].in > 0 && map[k].out > 0 && Math.abs(map[k].in - map[k].out) > 0.001);
+    return issues;
+  }
+
+  // render the Google Charts Sankey
+  function drawChart(data) {
+    const rows = [['From', 'To', 'Weight']];
+    data.forEach(d => rows.push([d.source, d.target, d.value]));
+    const dataTable = google.visualization.arrayToDataTable(rows);
+    const options = {
+      sankey: {
+        node: {
+          color: nodeColorInput.value,
+          label: { fontSize: parseInt(fontSizeInput.value, 10) || 12 }
+        },
+        link: { color: linkColorInput.value }
+      }
+    };
+    chart = new google.visualization.Sankey(chartDiv);
+    chart.draw(dataTable, options);
+  }
+
+  // handle drag & drop
+  dropZone.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    dropZone.classList.add('drag');
+  });
+  dropZone.addEventListener('dragleave', () => dropZone.classList.remove('drag'));
+  dropZone.addEventListener('drop', (e) => {
+    e.preventDefault();
+    dropZone.classList.remove('drag');
+    const file = e.dataTransfer.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => { textarea.value = reader.result.trim(); };
+    reader.readAsText(file);
+  });
+
+  // export helpers
+  function download(content, filename, type) {
+    const blob = new Blob([content], { type });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  exportCsvBtn.addEventListener('click', () => {
+    download(toCSV(chartData), 'data.csv', 'text/csv');
+  });
+  exportJsonBtn.addEventListener('click', () => {
+    download(JSON.stringify(chartData, null, 2), 'data.json', 'application/json');
+  });
+  exportPngBtn.addEventListener('click', () => {
+    if (!chart) return;
+    const uri = chart.getImageURI();
+    const a = document.createElement('a');
+    a.href = uri;
+    a.download = 'chart.png';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  });
+
+  // handle render button
+  renderBtn.addEventListener('click', () => {
+    const { data, error } = parseInput(textarea.value);
+    if (error) { showError(error); return; }
+    const issues = validateData(data);
+    if (issues.length) {
+      showError('Flow mismatch at nodes: ' + issues.join(', '));
+      return;
+    }
+    clearError();
+    chartData = data;
+    drawChart(chartData);
+  });
+
+  // load google charts and draw default
+  google.charts.load('current', { packages: ['sankey'] });
+  google.charts.setOnLoadCallback(() => {
+    chartData = defaultData;
+    textarea.value = toCSV(defaultData);
+    drawChart(defaultData);
+  });
+});

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -43,3 +43,15 @@ input {
   text-decoration: none;
   border-radius: 4px;
 }
+
+/* Drag and drop area styling for Sankey app */
+.drop-zone {
+  border: 2px dashed #888;
+  background: #fff;
+  padding: 20px;
+  text-align: center;
+  margin-bottom: 20px;
+}
+.drop-zone.drag {
+  background: #eef;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,6 +15,7 @@
   <div class="btn-container">
     <a class="app-link" href="oecd.html">OECD TPG Viewer</a>
     <a class="app-link" href="nace.html">NACE Rev. 2.1 Code Finder</a>
+    <a class="app-link" href="sankey.html">Sankey Diagram Generator</a>
   </div>
 </body>
 </html>

--- a/docs/sankey.html
+++ b/docs/sankey.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Sankey Diagram Generator</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="assets/style.css" />
+  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+</head>
+<body>
+  <div style="text-align:center;margin-bottom:20px;">
+    <a class="app-link" href="index.html">Home</a>
+  </div>
+  <h1 style="text-align:center;">Sankey Diagram Generator</h1>
+  <div id="drop-zone" class="drop-zone">Drop CSV or JSON file here</div>
+  <textarea id="data-input" rows="6" placeholder="Enter CSV or JSON data"></textarea>
+  <div style="margin-bottom:10px;">
+    <label>Node Color: <input type="color" id="nodeColor" value="#a6cee3"></label>
+    <label>Link Color: <input type="color" id="linkColor" value="#1f78b4"></label>
+    <label>Font Size: <input type="number" id="fontSize" value="12" style="width:60px;"></label>
+  </div>
+  <button id="render-btn">Render</button>
+  <div id="error" style="color:red;margin-top:10px;"></div>
+  <div id="chart" style="margin-top:20px;"></div>
+  <div style="margin-top:20px;">
+    <button id="export-csv">Export CSV</button>
+    <button id="export-json">Export JSON</button>
+    <button id="export-png">Download PNG</button>
+  </div>
+  <script src="assets/sankey/sankey.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Sankey diagram generator page with Google Charts
- create supporting JS with CSV/JSON import, export and PNG download
- style drag and drop zone
- link new page from the homepage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68486cccb69483299ee260188fad9942