### PR TITLE
Improve side-by-side viewer and add static Charted tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a small static website with several tools:
 3. **NAICS Code Finder** – a similar viewer for the North American Industry Classification System.
 4. **Side‑by‑Side Viewer** – display the NACE and NAICS finders together for easy comparison.
 5. **Sankey Diagram Generator** – create simple Sankey diagrams from CSV/JSON data.
-6. **Charted** – A Flask-based organisational chart builder by A.C. van der Linde (see `docs/assets/charted_app/`).
+6. **Charted** – A client-side organisational chart builder powered by D3.js.
 
 The site is contained entirely in the `docs/` directory and can be used locally or hosted on any static web server.
 
@@ -21,7 +21,7 @@ No build step is required. Open `docs/index.html` in a web browser. From there y
 * `naics.html` – loads `assets/naics/naics-app.js` for viewing NAICS data.
 * `nace-naics.html` – shows both viewers side by side on one page.
 * `sankey.html` – a simple page for creating Sankey diagrams.
-* `charted.html` – instructions for running the Charted organisational chart builder.
+* `charted.html` – a static organisational chart builder that runs entirely in the browser.
 
 ## File Layout
 
@@ -33,7 +33,7 @@ No build step is required. Open `docs/index.html` in a web browser. From there y
   naics.html          # NAICS Code Finder page
   nace-naics.html     # Combined viewer for NACE and NAICS
   sankey.html         # Sankey Diagram Generator page
-  charted.html        # Instructions for Charted app
+  charted.html        # Client-side organisational chart builder
   /assets
     style.css            # Shared styles
     /oecd
@@ -50,6 +50,8 @@ No build step is required. Open `docs/index.html` in a web browser. From there y
     /naics
       naics_data.json      # Dataset of NAICS codes
       naics-app.js         # React app for the NAICS finder
+    /charted_static
+      charted.js           # Browser-based organisational chart builder
 ```
 
 ## Notes

--- a/docs/assets/charted_static/charted.js
+++ b/docs/assets/charted_static/charted.js
@@ -1,0 +1,94 @@
+function readCsv(file) {
+  return new Promise((resolve, reject) => {
+    if (!file) return reject('No file provided');
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = reader.result;
+      const rows = text.trim().split(/\r?\n/).map(r => r.split(','));
+      const headers = rows.shift();
+      const data = rows.map(r => {
+        const obj = {};
+        headers.forEach((h,i) => obj[h.trim()] = r[i] ? r[i].trim() : '');
+        return obj;
+      });
+      resolve(data);
+    };
+    reader.onerror = () => reject('Failed to read file');
+    reader.readAsText(file);
+  });
+}
+
+function buildHierarchy(records) {
+  const stratify = d3.stratify().id(d => d.id).parentId(d => d.parent);
+  return stratify(records);
+}
+
+function drawChart(root) {
+  d3.select('#chart').selectAll('*').remove();
+  const width = 800;
+  const dx = 10;
+  const dy = width / 6;
+  const tree = d3.tree().nodeSize([dx, dy]);
+  const rootHier = tree(root);
+  let x0 = Infinity;
+  let x1 = -x0;
+  rootHier.each(d => {
+    if (d.x > x1) x1 = d.x;
+    if (d.x < x0) x0 = d.x;
+  });
+  const svg = d3.select('#chart').append('svg')
+      .attr('viewBox', [0, 0, width, x1 - x0 + dx * 2])
+      .style('font', '10px sans-serif')
+      .style('user-select', 'none');
+
+  const g = svg.append('g').attr('transform', `translate(${dy / 3},${dx - x0})`);
+
+  const link = g.append('g')
+      .attr('fill', 'none')
+      .attr('stroke', '#555')
+      .attr('stroke-opacity', 0.4)
+      .attr('stroke-width', 1.5)
+    .selectAll('path')
+    .data(rootHier.links())
+    .join('path')
+      .attr('d', d3.linkHorizontal()
+          .x(d => d.y)
+          .y(d => d.x));
+
+  const node = g.append('g')
+      .attr('stroke-linejoin', 'round')
+      .attr('stroke-width', 3)
+    .selectAll('g')
+    .data(rootHier.descendants())
+    .join('g')
+      .attr('transform', d => `translate(${d.y},${d.x})`);
+
+  node.append('circle')
+      .attr('fill', d => d.children ? '#555' : '#999')
+      .attr('r', 4);
+
+  node.append('text')
+      .attr('dy', '0.31em')
+      .attr('x', d => d.children ? -6 : 6)
+      .attr('text-anchor', d => d.children ? 'end' : 'start')
+      .text(d => d.name)
+    .clone(true).lower()
+      .attr('stroke', 'white');
+}
+
+async function handleGenerate() {
+  const file = document.getElementById('csvfile').files[0];
+  if (!file) {
+    alert('Please select a CSV file with id,parent,name columns.');
+    return;
+  }
+  try {
+    const records = await readCsv(file);
+    const root = buildHierarchy(records);
+    drawChart(root);
+  } catch(err) {
+    alert('Failed to parse CSV: ' + err);
+  }
+}
+
+document.getElementById('generate').addEventListener('click', handleGenerate);

--- a/docs/assets/combined/nace-naics-combined.js
+++ b/docs/assets/combined/nace-naics-combined.js
@@ -1,0 +1,141 @@
+function NACE_NAICS_Combined() {
+  const { useState, useEffect } = React;
+  const [query, setQuery] = useState('');
+  const [naceData, setNaceData] = useState([]);
+  const [naicsData, setNaicsData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    Promise.all([
+      fetch('assets/nace/nace_data.json').then(r => r.json()),
+      fetch('assets/naics/naics_data.json').then(r => r.json())
+    ]).then(([nace, naics]) => {
+      setNaceData(nace);
+      setNaicsData(naics);
+      setLoading(false);
+    }).catch(err => {
+      setError('Error: ' + err.message);
+      setLoading(false);
+    });
+  }, []);
+
+  const formatText = (text) => {
+    if (!text) return null;
+    const lines = text.split('\n');
+    let listItems = [];
+    const parts = [];
+    const flush = () => {
+      if (listItems.length > 0) {
+        parts.push(
+          React.createElement('ul', {style:{marginLeft:'20px',marginBottom:'4px'}},
+            listItems.map((li,idx)=>React.createElement('li',{key:idx},li))
+          )
+        );
+        listItems = [];
+      }
+    };
+    lines.forEach((line,idx)=>{
+      const t = line.trim();
+      if (!t) return;
+      if (t.startsWith('•') || t.startsWith('-')) {
+        listItems.push(t.replace(/^[•-]\s*/, ''));
+      } else {
+        flush();
+        parts.push(React.createElement('div',{key:`p-${idx}`,style:{marginBottom:'4px'}},t));
+      }
+    });
+    flush();
+    return React.createElement('div', null, ...parts);
+  };
+
+  const filterItems = (items) => {
+    if (!query) return [];
+    const q = query.toLowerCase();
+    return items.filter(it =>
+      Object.values(it).some(v => v && v.toString().toLowerCase().includes(q))
+    );
+  };
+
+  const filteredNace = filterItems(naceData);
+  const filteredNaics = filterItems(naicsData);
+
+  if (loading) return React.createElement('div',{style:{padding:'20px',textAlign:'center'}},'Loading data...');
+  if (error) return React.createElement('div',{style:{padding:'20px',textAlign:'center'}},error);
+
+  return (
+    React.createElement('div', null,
+      React.createElement('div',{style:{textAlign:'center',marginBottom:'16px'}},
+        React.createElement('input', {
+          type:'text',
+          placeholder:'Search NACE and NAICS...',
+          value: query,
+          onChange: e => setQuery(e.target.value),
+          style:{width:'100%',maxWidth:'600px',padding:'10px'}
+        })
+      ),
+      React.createElement('div',{className:'container'},
+        React.createElement('div',{className:'viewer'},
+          React.createElement('h2', null, 'NACE Results'),
+          filteredNace.length>0 ? filteredNace.map((item,idx)=>
+            React.createElement('div',{key:idx,style:{marginBottom:'16px',padding:'16px',backgroundColor:'#fff',border:'1px solid #ddd',borderRadius:'4px',boxShadow:'0 2px 4px rgba(0,0,0,0.1)'}},
+              React.createElement('div',{style:{marginBottom:'12px'}},
+                React.createElement('strong',null,'Code: '),
+                React.createElement('span',{style:{fontWeight:'bold',color:'#007bff'}}, item.CODE.toString())
+              ),
+              React.createElement('div',{style:{marginBottom:'12px'}},
+                React.createElement('strong',null,'Name: '),
+                React.createElement('span',null,item.NAME)
+              ),
+              item.Includes ? React.createElement('div',{style:{marginBottom:'12px'}},
+                React.createElement('strong',{style:{display:'block',marginBottom:'4px'}},'Includes:'),
+                formatText(item.Includes)
+              ) : null,
+              item.IncludesAlso ? React.createElement('div',{style:{marginBottom:'12px'}},
+                React.createElement('strong',{style:{display:'block',marginBottom:'4px'}},'Includes Also:'),
+                formatText(item.IncludesAlso)
+              ) : null,
+              item.Excludes ? React.createElement('div',{style:{marginBottom:'12px'}},
+                React.createElement('strong',{style:{display:'block',marginBottom:'4px'}},'Excludes:'),
+                formatText(item.Excludes)
+              ) : null
+            )
+          ) : React.createElement('p',{style:{textAlign:'center'}},'No results.')
+        ),
+        React.createElement('div',{className:'viewer'},
+          React.createElement('h2', null, 'NAICS Results'),
+          filteredNaics.length>0 ? filteredNaics.map((item,idx)=>
+            React.createElement('div',{key:idx,style:{marginBottom:'16px',padding:'16px',backgroundColor:'#fff',border:'1px solid #ddd',borderRadius:'4px',boxShadow:'0 2px 4px rgba(0,0,0,0.1)'}},
+              React.createElement('div',{style:{marginBottom:'12px'}},
+                React.createElement('strong',null,'Code: '),
+                React.createElement('span',{style:{fontWeight:'bold',color:'#007bff'}}, item.Code.toString())
+              ),
+              React.createElement('div',{style:{marginBottom:'12px'}},
+                React.createElement('strong',null,'Name: '),
+                React.createElement('span',null,item.Name)
+              ),
+              item.Description ? React.createElement('div',{style:{marginBottom:'12px'}},
+                React.createElement('strong',{style:{display:'block',marginBottom:'4px'}},'Description:'),
+                formatText(item.Description)
+              ) : null,
+              item["Cross-Reference"] ? React.createElement('div',{style:{marginBottom:'12px'}},
+                React.createElement('strong',{style:{display:'block',marginBottom:'4px'}},'Cross-Reference:'),
+                formatText(item["Cross-Reference"])
+              ) : null
+            )
+          ) : React.createElement('p',{style:{textAlign:'center'}},'No results.')
+        )
+      )
+    )
+  );
+}
+
+window.renderNaceNaicsCombined = function(rootId) {
+  ReactDOM.createRoot(document.getElementById(rootId)).render(
+    React.createElement(NACE_NAICS_Combined)
+  );
+};
+
+if (document.currentScript && document.getElementById('root')) {
+  window.renderNaceNaicsCombined('root');
+}

--- a/docs/charted.html
+++ b/docs/charted.html
@@ -5,17 +5,24 @@
   <title>Charted - by A.C. van der Linde</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="assets/style.css" />
+  <style>
+    #chart svg { width: 100%; height: auto; }
+  </style>
+  <script src="https://d3js.org/d3.v7.min.js"></script>
 </head>
 <body>
   <div style="text-align:center;margin-bottom:20px;">
     <a class="app-link" href="index.html">Home</a>
   </div>
-  <h1 style="text-align:center;">Charted - by A.C. van der Linde</h1>
-  <p>This repository includes the source code for the Charted application in the
-    <code>docs/assets/charted_app/</code> folder. To run the Flask app locally install the
-    dependencies and execute <code>python docs/assets/charted_app/app.py</code>.</p>
-  <pre><code>pip install flask flask_session pandas sqlalchemy pydantic
-python docs/assets/charted_app/app.py</code></pre>
-  <p>The application will start on <code>http://localhost:5000/</code>.</p>
+  <h1 style="text-align:center;">Charted - Client Version</h1>
+  <p style="text-align:center;">Upload a CSV file with <code>id,parent,name</code> columns to generate an organisational chart entirely in your browser.</p>
+  <div style="text-align:center;margin-bottom:10px;">
+    <input type="file" id="csvfile" accept=".csv" />
+  </div>
+  <div style="text-align:center;margin-bottom:20px;">
+    <button id="generate" class="app-link">Generate Chart</button>
+  </div>
+  <div id="chart"></div>
+  <script src="assets/charted_static/charted.js"></script>
 </body>
 </html>

--- a/docs/nace-naics.html
+++ b/docs/nace-naics.html
@@ -16,15 +16,10 @@
   <div style="text-align:center;margin-bottom:20px;">
     <a class="app-link" href="index.html">Home</a>
   </div>
-  <div class="container">
-    <div id="nace-root" class="viewer"></div>
-    <div id="naics-root" class="viewer"></div>
-  </div>
-  <script src="assets/nace/nace-app.js"></script>
-  <script src="assets/naics/naics-app.js"></script>
+  <div id="root"></div>
+  <script src="assets/combined/nace-naics-combined.js"></script>
   <script>
-    renderNACECodeFinder('nace-root');
-    renderNAICSCodeFinder('naics-root');
+    renderNaceNaicsCombined('root');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- combine NACE and NAICS search into a single viewer
- ensure results appear side by side
- replace Charted Flask instructions with a static D3 implementation
- document new static charted tool in README

## Testing
- `python -m py_compile docs/assets/charted_app/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6874bf1aeda0832f8388bba25985d7c9