### PR TITLE
Enable inline ChartPal CSV data and split NACE/NAICS viewer

### DIFF
--- a/docs/assets/chartpal_static/chartpal.js
+++ b/docs/assets/chartpal_static/chartpal.js
@@ -93,14 +93,25 @@ function drawChart(root) {
       .attr('stroke', 'white');
 }
 
+function parseCsvText(text) {
+  const rows = text.trim().split(/\r?\n/).map(r => r.split(','));
+  const headers = rows.shift();
+  return rows.map(r => {
+    const obj = {};
+    headers.forEach((h,i) => obj[h.trim()] = r[i] ? r[i].trim() : '');
+    return obj;
+  });
+}
+
 async function handleGenerate() {
   const file = document.getElementById('csvfile').files[0];
-  if (!file) {
-    alert('Please select a CSV file with id,parent,name[,ownership,jurisdiction] columns.');
+  const text = document.getElementById('csvtext').value.trim();
+  if (!file && !text) {
+    alert('Please provide a CSV file or paste data with id,parent,name,ownership,jurisdiction columns.');
     return;
   }
   try {
-    const records = await readCsv(file);
+    const records = file ? await readCsv(file) : parseCsvText(text);
     const root = buildHierarchy(records);
     drawChart(root);
   } catch(err) {

--- a/docs/chartpal.html
+++ b/docs/chartpal.html
@@ -15,9 +15,12 @@
     <a class="app-link" href="index.html">Home</a>
   </div>
   <h1 style="text-align:center;">ChartPal</h1>
-  <p style="text-align:center;">Upload a CSV file with <code>id,parent,name[,ownership,jurisdiction]</code> columns to generate an organisational chart entirely in your browser.</p>
+  <p style="text-align:center;">Upload a CSV file or paste CSV text with <code>id,parent,name,ownership (%),jurisdiction</code> columns to generate an organisational chart entirely in your browser.</p>
   <div style="text-align:center;margin-bottom:10px;">
     <input type="file" id="csvfile" accept=".csv" />
+  </div>
+  <div style="text-align:center;margin-bottom:10px;">
+    <textarea id="csvtext" rows="6" style="width:90%;max-width:800px;" placeholder="id,parent,name,ownership,jurisdiction&#10;1,,Parent Co,100,US&#10;2,1,Subsidiary,80,DE"></textarea>
   </div>
   <div style="text-align:center;margin-bottom:20px;">
     <button id="generate" class="app-link">Generate Chart</button>

--- a/docs/nace-naics.html
+++ b/docs/nace-naics.html
@@ -18,12 +18,27 @@
     <a class="app-link" href="index.html">Home</a>
   </div>
 
-  <!-- wrap both viewers in the same flex container -->
-  <div id="root" class="container"></div>
+  <!-- explanation of NAICS symbols -->
+  <div id="symbol-explanation" style="padding:20px; max-width:800px; margin:0 auto;">
+    <h2>Explanation of Symbols</h2>
+    <h3>In titles and descriptions of industries</h3>
+    <table class="symbol-table">
+      <tr><th>Symbol</th><th>Explanation</th></tr>
+      <tr><td>T</td><td>Canadian, Mexican, and United States industries are comparable</td></tr>
+    </table>
+  </div>
 
-  <script src="assets/combined/nace-naics-combined.js"></script>
+  <!-- side-by-side viewers -->
+  <div class="container">
+    <div id="nace-root" class="viewer"></div>
+    <div id="naics-root" class="viewer"></div>
+  </div>
+
+  <script src="assets/nace/nace-app.js"></script>
+  <script src="assets/naics/naics-app.js"></script>
   <script>
-    renderNaceNaicsCombined('root');
+    renderNACECodeFinder('nace-root');
+    renderNAICSCodeFinder('naics-root');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow pasting CSV text directly in ChartPal
- handle pasted text in ChartPal script
- replace combined NACE/NAICS viewer with two standalone viewers
- show explanation of "T" symbol on the combined page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6874e0a4c9c4832f9201bddb641dd35e