### PR TITLE
Unify NACE/NAICS search and update ChartPal format

### DIFF
--- a/docs/assets/chartpal_static/chartpal.js
+++ b/docs/assets/chartpal_static/chartpal.js
@@ -18,8 +18,24 @@ function readCsv(file) {
   });
 }
 
+function parseOwnership(value) {
+  if (!value && value !== 0) return null;
+  let v = value.toString().trim();
+  if (v.endsWith('%')) v = v.slice(0, -1);
+  let num = parseFloat(v);
+  if (isNaN(num)) return null;
+  if (num <= 1) num = num * 100;
+  return Math.round(num * 100) / 100; // keep two decimals
+}
+
 function buildHierarchy(records) {
-  const stratify = d3.stratify().id(d => d.id).parentId(d => d.parent);
+  records.forEach(rec => {
+    if (rec['ownership%'] !== undefined) {
+      const val = parseOwnership(rec['ownership%']);
+      if (val !== null) rec['ownership%'] = val;
+    }
+  });
+  const stratify = d3.stratify().id(d => d.id).parentId(d => d.parent_id);
   return stratify(records);
 }
 
@@ -82,7 +98,9 @@ function drawChart(root) {
       .attr('text-anchor', d => d.children ? 'end' : 'start')
       .text(d => {
         let label = d.data.name || d.id;
-        if (d.data.ownership) label += ` (${d.data.ownership}%)`;
+        if (d.data['ownership%'] !== undefined && d.data['ownership%'] !== null) {
+          label += ` (${d.data['ownership%']}%)`;
+        }
         if (d.data.jurisdiction) {
           const flag = countryFlagEmoji(d.data.jurisdiction);
           label = `${flag} ${label}`;
@@ -107,7 +125,7 @@ async function handleGenerate() {
   const file = document.getElementById('csvfile').files[0];
   const text = document.getElementById('csvtext').value.trim();
   if (!file && !text) {
-    alert('Please provide a CSV file or paste data with id,parent,name,ownership,jurisdiction columns.');
+    alert('Please provide a CSV file or paste data with id,parent_id,name,ownership%,jurisdiction columns.');
     return;
   }
   try {

--- a/docs/chartpal.html
+++ b/docs/chartpal.html
@@ -15,12 +15,17 @@
     <a class="app-link" href="index.html">Home</a>
   </div>
   <h1 style="text-align:center;">ChartPal</h1>
-  <p style="text-align:center;">Upload a CSV file or paste CSV text with <code>id,parent,name,ownership (%),jurisdiction</code> columns to generate an organisational chart entirely in your browser.</p>
+  <p style="text-align:center;">Upload a CSV file or paste CSV text with <code>id,parent_id,name,ownership%,jurisdiction</code> columns to generate an organisational chart entirely in your browser. The <code>ownership%</code> field accepts values like <code>25%</code> or <code>0.25</code>.</p>
+  <pre id="sample-data" style="width:90%;max-width:800px;margin:0 auto 10px auto;background:#f7f7f7;padding:10px;overflow:auto;">
+id,parent_id,name,ownership%,jurisdiction
+1,,Parent Co,100%,US
+2,1,Subsidiary,80%,DE
+</pre>
   <div style="text-align:center;margin-bottom:10px;">
     <input type="file" id="csvfile" accept=".csv" />
   </div>
   <div style="text-align:center;margin-bottom:10px;">
-    <textarea id="csvtext" rows="6" style="width:90%;max-width:800px;" placeholder="id,parent,name,ownership,jurisdiction&#10;1,,Parent Co,100,US&#10;2,1,Subsidiary,80,DE"></textarea>
+    <textarea id="csvtext" rows="6" style="width:90%;max-width:800px;" placeholder="id,parent_id,name,ownership%,jurisdiction&#10;1,,Parent Co,100%,US&#10;2,1,Subsidiary,80%,DE"></textarea>
   </div>
   <div style="text-align:center;margin-bottom:20px;">
     <button id="generate" class="app-link">Generate Chart</button>

--- a/docs/nace-naics.html
+++ b/docs/nace-naics.html
@@ -28,17 +28,12 @@
     </table>
   </div>
 
-  <!-- side-by-side viewers -->
-  <div class="container">
-    <div id="nace-root" class="viewer"></div>
-    <div id="naics-root" class="viewer"></div>
-  </div>
+  <!-- combined search viewer -->
+  <div id="combined-root" style="margin-top:20px;"></div>
 
-  <script src="assets/nace/nace-app.js"></script>
-  <script src="assets/naics/naics-app.js"></script>
+  <script src="assets/combined/nace-naics-combined.js"></script>
   <script>
-    renderNACECodeFinder('nace-root');
-    renderNAICSCodeFinder('naics-root');
+    renderNaceNaicsCombined('combined-root');
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update ChartPal to require `id`, `parent_id`, and `name`
- allow `ownership%` in either 0-1 or 0-100 form and display sample data
- show example CSV above text area for easy copy/paste
- swap the side‑by‑side viewer with a combined NACE+NAICS search that filters both datasets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6874e354b1dc832fa1e564b44746b1e2