### PR TITLE
Fix ChartPal layout for large charts

### DIFF
--- a/docs/assets/chartpal_static/chartpal.js
+++ b/docs/assets/chartpal_static/chartpal.js
@@ -50,7 +50,9 @@ function countryFlagEmoji(code) {
 
 function drawChart(root) {
   d3.select('#chart').selectAll('*').remove();
-  const width = 800;
+  const container = document.getElementById('chart');
+  const containerWidth = container ? container.clientWidth : 800;
+  const width = Math.max(containerWidth, 800);
   const dx = 10;
   const dy = width / 6;
   const tree = d3.tree().nodeSize([dx, dy]);

--- a/docs/chartpal.html
+++ b/docs/chartpal.html
@@ -6,6 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="assets/style.css" />
   <style>
+    body { max-width: none; }
+    #chart { width: 100%; overflow: auto; }
     #chart svg { width: 100%; height: auto; }
   </style>
   <script src="https://d3js.org/d3.v7.min.js"></script>


### PR DESCRIPTION
## Summary
- make ChartPal body fill the screen instead of max-width 800px
- make chart scale with container width

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687517d1564c832f814fac484e0ab2d3