### PR TITLE
Fix ChartPal asset paths

### DIFF
--- a/docs/assets/chartpal/chartpal.js
+++ b/docs/assets/chartpal/chartpal.js
@@ -1,8 +1,9 @@
 
 // Minimal ASCII-based organisational chart builder
 let countryNames = {};
+let currentCsvText = '';
 
-async function loadCountryNames(url = 'countryNames.json') {
+async function loadCountryNames(url = 'country_names.json') {
   try {
     const response = await fetch(url);
     if (!response.ok) throw new Error('Could not load country names');

--- a/docs/chartpal.html
+++ b/docs/chartpal.html
@@ -5,6 +5,7 @@
   <title>ChartPal</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="assets/style.css" />
+  <link rel="stylesheet" href="assets/chartpal/style.css" />
   <style>
     body { max-width: none; }
     #ascii-chart { width:90%;max-width:800px;margin:20px auto;padding:10px;background:#f7f7f7;overflow:auto; }
@@ -35,7 +36,9 @@ id,parent_id,name,ownership%,jurisdiction
     <label for="country-info">Jurisdictions:</label>
     <select id="country-info"></select>
   </div>
+  <div id="error-box" style="color:red;margin-bottom:10px;text-align:center;"></div>
   <pre id="ascii-chart"></pre>
-  <script src="assets/chartpal/static/chartpal.js"></script>
+  <script src="assets/chartpal/papaparse.min.js"></script>
+  <script src="assets/chartpal/chartpal.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- correct default country file name and add missing global state
- load papaparse and style sheet in ChartPal
- show error messages and fix script path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687f76304694832f82a6683c91010944