### PR TITLE
Fix ChartPal asset links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a small static website with several tools:
 3. **NAICS Code Finder** – a similar viewer for the North American Industry Classification System.
 4. **Side‑by‑Side Viewer** – display the NACE and NAICS finders together for easy comparison.
 5. **Sankey Diagram Generator** – create simple Sankey diagrams from CSV/JSON data.
-6. **ChartPal** – A client-side organisational chart builder powered by D3.js.
+6. **ChartPal** – A client-side organisational chart builder written in vanilla JavaScript.
 
 The site is contained entirely in the `docs/` directory and can be used locally or hosted on any static web server.
 
@@ -51,9 +51,10 @@ No build step is required. Open `docs/index.html` in a web browser. From there y
       naics_data.json      # Dataset of NAICS codes
       naics-app.js         # React app for the NAICS finder
     /chartpal
-      app.py               # Simple Flask backend
-      /static
-        chartpal.js        # Browser-based organisational chart builder
+      chartpal.js        # Browser-based organisational chart builder
+      papaparse.min.js   # CSV parsing library
+      country_names.json # Reference for jurisdiction codes
+      style.css          # Styles for ChartPal
 ```
 
 ## Notes

--- a/docs/assets/chartpal/chartpal.js
+++ b/docs/assets/chartpal/chartpal.js
@@ -5,7 +5,7 @@ let currentZoom = 100; // Zoom level in percent
 
 // --- DATA & PARSING ---
 
-async function loadCountryNames(url = 'https://gist.githubusercontent.com/tmrk/e82208753a2205a278fc/raw/b1875e5330a133483983d7350c3752a7d4d76cf2/country_names.json') {
+async function loadCountryNames(url = 'assets/chartpal/country_names.json') {
     try {
         const response = await fetch(url);
         if (!response.ok) throw new Error('Could not load country names');

--- a/docs/chartpal.html
+++ b/docs/chartpal.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ChartPal - Org Chart Builder</title>
-    <link rel="stylesheet" href="style.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js"></script>
+    <link rel="stylesheet" href="assets/chartpal/style.css">
+    <script src="assets/chartpal/papaparse.min.js"></script>
 </head>
 <body>
     <h1>ChartPal 🏢 Organizational Chart Builder</h1>
@@ -63,6 +63,6 @@
         <div id="error-box"></div>
     </div>
 
-    <script src="chartpal.js"></script>
+    <script src="assets/chartpal/chartpal.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fix ChartPal HTML to use local assets
- load local country name data by default
- update README description and file layout for ChartPal

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_687fe9bf78ec832fa51f4c31bed54450