### PR TITLE
Fix ChartPal initialization and HTML

### DIFF
--- a/docs/assets/chartpal/chartpal.js
+++ b/docs/assets/chartpal/chartpal.js
@@ -15,7 +15,9 @@ async function loadCountryNames(url = 'assets/chartpal/country_names.json') {
             acc[country.code] = country.name;
             return acc;
         }, {});
-        populateJurisdictionReference();
+        if (document.getElementById('jurisdiction-list')) {
+            populateJurisdictionReference();
+        }
     } catch (e) {
         console.error('Failed to load country names:', e);
         showError('Could not load country reference list.');
@@ -192,6 +194,7 @@ function updateZoom(newZoom) {
 
 function populateJurisdictionReference() {
     const list = document.getElementById('jurisdiction-list');
+    if (!list) return;
     list.innerHTML = ''; // Clear existing
     Object.entries(countryNames).forEach(([code, name]) => {
         const li = document.createElement('li');
@@ -202,7 +205,9 @@ function populateJurisdictionReference() {
 }
 
 function filterJurisdictionList() {
-    const filter = document.getElementById('jurisdiction-search').value.toLowerCase();
+    const search = document.getElementById('jurisdiction-search');
+    if (!search) return;
+    const filter = search.value.toLowerCase();
     const items = document.querySelectorAll('#jurisdiction-list li');
     items.forEach(item => {
         if (item.dataset.search.includes(filter)) {
@@ -215,20 +220,6 @@ function filterJurisdictionList() {
 
 // --- INITIALIZATION ---
 
-document.addEventListener('DOMContentLoaded', () => {
-    // Load external data
-    loadCountryNames();
-
-    // Setup event listeners
-    document.getElementById('generate').addEventListener('click', handleGenerate);
-    document.getElementById('download-csv').addEventListener('click', downloadCsv);
-    document.getElementById('zoom-in').addEventListener('click', () => updateZoom(currentZoom + 10));
-    document.getElementById('zoom-out').addEventListener('click', () => updateZoom(currentZoom - 10));
-    document.getElementById('jurisdiction-search').addEventListener('input', filterJurisdictionList);
-    
-    // Auto-generate chart from sample data on load
-    handleGenerate();
-});
 
 // --- NEW Globals & State Management ---
 let chartNodes = new Map(); // Stores node data { id, name, parent_id, etc. }
@@ -412,7 +403,8 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('export-csv').addEventListener('click', exportToCsv);
     document.getElementById('add-node').addEventListener('click', handleAddNode);
 
-    // Initial load with sample data
-    // The old handleGenerate can be renamed to handleImport
-    handleImport(); 
+    const initial = document.getElementById('csvtext').value.trim();
+    if (initial) {
+        handleImport();
+    }
 });

--- a/docs/chartpal.html
+++ b/docs/chartpal.html
@@ -1,27 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>ChartPal - Interactive Org Chart Builder</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="assets/style.css" />
+  <link rel="stylesheet" href="assets/chartpal/style.css" />
+  <script src="assets/chartpal/papaparse.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/leader-line@1.0.7/leader-line.min.js"></script>
+</head>
 <body>
-    <h1>ChartPal - Interactive Org Chart Builder</h1>
+  <div style="text-align:center;margin-bottom:20px;">
+    <a class="app-link" href="index.html">Home</a>
+  </div>
+  <h1 style="text-align:center;">ChartPal - Interactive Org Chart Builder</h1>
 
-    <div class="main-container">
-        <div class="editor-pane">
-            <div id="canvas" class="editor-canvas">
-                </div>
-        </div>
-
-        <div class="controls-pane">
-            <h2>Controls</h2>
-            <button id="add-node">Add Company Box</button>
-            <button id="export-csv">Export to CSV</button>
-            <hr>
-            <h2>Tree View</h2>
-            <pre id="tree-output-display"></pre> </div>
+  <div class="main-container">
+    <div class="editor-pane">
+      <div id="canvas" class="editor-canvas"></div>
     </div>
-
-    <div class="data-pane">
-        <h2>CSV Data</h2>
-        <p>You can paste CSV data here and click 'Import' to draw the chart, or edit the chart visually and click 'Export to CSV'.</p>
-        <textarea id="csvtext" rows="10" placeholder="id,parent_id,name,ownership%,jurisdiction..."></textarea>
-        <button id="import-from-csv">Import from CSV</button>
-        <div id="error-box" class="error"></div>
+    <div class="controls-pane">
+      <h2>Controls</h2>
+      <button id="add-node">Add Company Box</button>
+      <button id="export-csv">Export to CSV</button>
+      <hr>
+      <h2>Tree View</h2>
+      <pre id="tree-output-display"></pre>
     </div>
+  </div>
 
-    </body>
+  <div class="data-pane">
+    <h2>CSV Data</h2>
+    <p>You can paste CSV data here and click 'Import' to draw the chart, or edit the chart visually and click 'Export to CSV'.</p>
+    <textarea id="csvtext" rows="10" placeholder="id,parent_id,name,ownership%,jurisdiction..."></textarea>
+    <button id="import-from-csv">Import from CSV</button>
+    <div id="error-box" class="error"></div>
+  </div>
+
+  <script src="assets/chartpal/chartpal.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update country name loading to check for optional reference list
- guard jurisdiction list handling functions
- remove old DOMContentLoaded handler
- only auto-import CSV if textarea has data
- rebuild `chartpal.html` with full HTML structure

## Testing
- `node -e "require('fs').readFileSync('docs/assets/chartpal/chartpal.js');"`

------
https://chatgpt.com/codex/tasks/task_b_68809068a5b0832fa8b317ef4ecd66e1