### PR TITLE
Improve ChartPal layout and lines

### DIFF
--- a/docs/assets/chartpal/chartpal.js
+++ b/docs/assets/chartpal/chartpal.js
@@ -218,7 +218,7 @@ function populateJurisdictionReference() {
     list.innerHTML = ''; // Clear existing
     Object.entries(countryNames).forEach(([code, name]) => {
         const li = document.createElement('li');
-        li.textContent = `${countryFlagEmoji(code)} ${code} - ${name}`;
+        li.textContent = `${countryFlagEmoji(code)} ${name}`;
         li.dataset.search = `${code} ${name}`.toLowerCase();
         list.appendChild(li);
     });
@@ -312,7 +312,7 @@ function drawChartFromData(records) {
         const options = {
             color: '#007bff',
             size: 2,
-            path: 'straight',
+            path: 'grid',
             startSocket: 'bottom',
             endSocket: 'top',
             middleLabel: label
@@ -323,7 +323,9 @@ function drawChartFromData(records) {
         const line = new LeaderLine(parentEl, childEl, options);
         if (line.middleLabel && line.middleLabel.nodeType === 1) {
             line.middleLabel.style.transform = `scale(${1 / canvasScale})`;
+            line.middleLabel.style.pointerEvents = 'none';
         }
+        if (line.line) line.line.style.pointerEvents = 'none';
         chartLines.push(line);
         }
     });
@@ -437,7 +439,7 @@ function redrawLines() {
             const options = {
                 color: '#007bff',
                 size: 2,
-                path: 'straight',
+                path: 'grid',
                 startSocket: 'bottom',
                 endSocket: 'top',
                 middleLabel: label
@@ -448,7 +450,9 @@ function redrawLines() {
             const line = new LeaderLine(parentEl, childEl, options);
             if (line.middleLabel && line.middleLabel.nodeType === 1) {
                 line.middleLabel.style.transform = `scale(${1 / canvasScale})`;
+                line.middleLabel.style.pointerEvents = 'none';
             }
+            if (line.line) line.line.style.pointerEvents = 'none';
             chartLines.push(line);
         }
     });
@@ -594,6 +598,20 @@ function toggleConnectMode() {
     document.querySelectorAll('.chart-node.selected').forEach(el => el.classList.remove('selected'));
 }
 
+function layoutGrid() {
+    const nodes = Array.from(chartNodes.keys());
+    const cols = 4;
+    nodes.forEach((id, idx) => {
+        const el = document.getElementById(`node-${safeId(id)}`);
+        if (!el) return;
+        const col = idx % cols;
+        const row = Math.floor(idx / cols);
+        el.style.left = `${50 + col * 200}px`;
+        el.style.top = `${50 + row * 150}px`;
+    });
+    redrawLines();
+}
+
 function zoomCanvas(delta) {
     canvasScale = Math.max(0.2, Math.min(3, canvasScale + delta));
     document.getElementById('canvas').style.transform = `scale(${canvasScale})`;
@@ -649,6 +667,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('change-ownership').addEventListener('click', handleChangeOwnership);
     document.getElementById('zoom-in').addEventListener('click', () => zoomCanvas(0.1));
     document.getElementById('zoom-out').addEventListener('click', () => zoomCanvas(-0.1));
+    document.getElementById('layout-grid').addEventListener('click', layoutGrid);
     initCanvasPan();
 
     if (window.twemoji) twemoji.parse(document.body);

--- a/docs/assets/chartpal/leader-line.min.js
+++ b/docs/assets/chartpal/leader-line.min.js
@@ -19,6 +19,7 @@
       svg.style.left='0';
       svg.style.width='100%';
       svg.style.height='100%';
+      svg.style.pointerEvents='none';
       document.getElementById('canvas').appendChild(svg);
     }
     return svg;
@@ -39,12 +40,14 @@
   }
   function LeaderLine(start,end,opts){
     this.start=start;this.end=end;this.opts=opts||{};this.overlay=getOverlay();
-    this.line=document.createElementNS('http://www.w3.org/2000/svg','line');
+    this.line=document.createElementNS('http://www.w3.org/2000/svg',this.opts.path==='grid'?'path':'line');
     this.line.setAttribute('stroke',this.opts.color||'#000');
     this.line.setAttribute('stroke-width',this.opts.size||2);
     if(this.opts.dash){
       this.line.setAttribute('stroke-dasharray',this.opts.dash.len+' '+this.opts.dash.gap);
     }
+    this.line.setAttribute('fill','none');
+    this.line.style.pointerEvents='none';
     this.overlay.appendChild(this.line);
     if(this.opts.middleLabel){
       this.middleLabel=this.opts.middleLabel;
@@ -55,10 +58,16 @@
   LeaderLine.prototype.position=function(){
     const s=getPoint(this.start,this.opts.startSocket);
     const e=getPoint(this.end,this.opts.endSocket);
-    this.line.setAttribute('x1',s.x);
-    this.line.setAttribute('y1',s.y);
-    this.line.setAttribute('x2',e.x);
-    this.line.setAttribute('y2',e.y);
+    if(this.opts.path==='grid'){
+      const midY=(s.y+e.y)/2;
+      const d='M'+s.x+' '+s.y+' L'+s.x+' '+midY+' L'+e.x+' '+midY+' L'+e.x+' '+e.y;
+      this.line.setAttribute('d',d);
+    }else{
+      this.line.setAttribute('x1',s.x);
+      this.line.setAttribute('y1',s.y);
+      this.line.setAttribute('x2',e.x);
+      this.line.setAttribute('y2',e.y);
+    }
     if(this.middleLabel){
       this.middleLabel.style.left=(s.x+e.x)/2+'px';
       this.middleLabel.style.top=(s.y+e.y)/2+'px';

--- a/docs/assets/chartpal/style.css
+++ b/docs/assets/chartpal/style.css
@@ -22,6 +22,12 @@
     padding: 10px;
     overflow-y: auto;
 }
+.tree-pane {
+    width: 250px;
+    border: 1px solid #ccc;
+    padding: 10px;
+    overflow-y: auto;
+}
 .data-pane {
     margin-top: 20px;
 }

--- a/docs/chartpal.html
+++ b/docs/chartpal.html
@@ -18,6 +18,10 @@
   <p class="legend" style="text-align:center;">Solid line = 100% ownership, dotted line = less than 100% ownership.</p>
 
   <div class="main-container">
+    <div class="tree-pane">
+      <h2>Tree View</h2>
+      <pre id="tree-output-display"></pre>
+    </div>
     <div class="editor-pane">
       <div id="canvas" class="editor-canvas"></div>
     </div>
@@ -44,9 +48,7 @@
         <button id="zoom-out">Zoom Out</button>
         <span id="zoom-display">100%</span>
       </div>
-      <hr>
-      <h2>Tree View</h2>
-      <pre id="tree-output-display"></pre>
+      <button id="layout-grid">Grid Layout</button>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- move the Tree View to its own pane on the left
- add Grid Layout button for arranging chart boxes
- show flag emoji then name in jurisdiction list
- use rectangular connecting lines and allow moving boxes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6880bf82fe40832faf4b8eaf3aeaeb61