### PR TITLE
Improve ChartPal layout and add branch nodes

### DIFF
--- a/docs/assets/chartpal/chartpal.js
+++ b/docs/assets/chartpal/chartpal.js
@@ -342,18 +342,23 @@ function renderNode(nodeData, x, y) {
     const nodeEl = document.createElement('div');
     nodeEl.id = `node-${safeId(nodeData.id)}`;
     nodeEl.className = 'chart-node';
+    if (nodeData.isBranch) nodeEl.classList.add('branch-node');
     nodeEl.dataset.id = nodeData.id;
     nodeEl.style.left = `${x}px`;
     nodeEl.style.top = `${y}px`;
 
     // Populate the box content
-    const flag = nodeData.jurisdiction ? countryFlagEmoji(nodeData.jurisdiction) : '';
-    const jurName = getJurisdictionName(nodeData.jurisdiction);
-    nodeEl.innerHTML = `
-        <span class="flag">${flag}</span>
-        <div class="company-name">${nodeData.name || 'Unnamed'}</div>
-        <div class="jurisdiction">${jurName}</div>
-    `;
+    if (nodeData.isBranch) {
+        nodeEl.textContent = nodeData.name || 'Branch';
+    } else {
+        const flag = nodeData.jurisdiction ? countryFlagEmoji(nodeData.jurisdiction) : '';
+        const jurName = getJurisdictionName(nodeData.jurisdiction);
+        nodeEl.innerHTML = `
+            <span class="flag">${flag}</span>
+            <div class="company-name">${nodeData.name || 'Unnamed'}</div>
+            <div class="jurisdiction">${jurName}</div>
+        `;
+    }
 
     canvas.appendChild(nodeEl);
     if (window.twemoji) twemoji.parse(nodeEl);
@@ -532,6 +537,20 @@ function handleAddNode() {
     redrawLines();
 }
 
+function handleAddBranch() {
+    const newId = (Math.max(0, ...Array.from(chartNodes.keys()).map(k => parseInt(k))) + 1).toString();
+    const newNodeData = {
+        id: newId,
+        parent_id: '0',
+        name: `Branch ${newId}`,
+        isBranch: true,
+        children: []
+    };
+    renderNode(newNodeData, 50, 50);
+    updateTreeView();
+    redrawLines();
+}
+
 function handleChangeJurisdiction() {
     if (!selectedNodeId) return;
     const input = document.getElementById('jurisdiction-input');
@@ -661,6 +680,8 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('import-from-csv').addEventListener('click', handleImport);
     document.getElementById('export-csv').addEventListener('click', exportToCsv);
     document.getElementById('add-node').addEventListener('click', handleAddNode);
+    const branchBtn = document.getElementById('add-branch');
+    if (branchBtn) branchBtn.addEventListener('click', handleAddBranch);
     document.getElementById('connect-nodes').addEventListener('click', toggleConnectMode);
     document.getElementById('change-jurisdiction').addEventListener('click', handleChangeJurisdiction);
     document.getElementById('change-name').addEventListener('click', handleChangeName);

--- a/docs/assets/chartpal/style.css
+++ b/docs/assets/chartpal/style.css
@@ -6,6 +6,7 @@
 }
 .editor-pane {
     flex-grow: 1;
+    min-width: 400px;
     border: 1px solid #ccc;
 }
 .editor-canvas {
@@ -17,7 +18,7 @@
     transform-origin: top left;
 }
 .controls-pane {
-    width: 350px;
+    width: 300px;
     border: 1px solid #ccc;
     padding: 10px;
     overflow-y: auto;
@@ -71,6 +72,14 @@
 }
 .chart-node.selected {
     border-color: #007bff;
+}
+
+.branch-node {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    line-height: 36px;
+    padding: 0;
 }
 
 .legend {

--- a/docs/chartpal.html
+++ b/docs/chartpal.html
@@ -6,11 +6,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="assets/style.css" />
   <link rel="stylesheet" href="assets/chartpal/style.css" />
+  <style>
+    body.chartpal-page { max-width: none; margin: 20px; }
+    body.chartpal-page .main-container { height: 80vh; }
+  </style>
   <script src="assets/chartpal/papaparse.min.js"></script>
   <script src="assets/chartpal/leader-line.min.js"></script>
   <script src="https://twemoji.maxcdn.com/v/latest/twemoji.min.js" crossorigin="anonymous"></script>
 </head>
-<body>
+<body class="chartpal-page">
   <div style="text-align:center;margin-bottom:20px;">
     <a class="app-link" href="index.html">Home</a>
   </div>
@@ -28,6 +32,7 @@
     <div class="controls-pane">
       <h2>Controls</h2>
       <button id="add-node">Add Company Box</button>
+      <button id="add-branch">Add Branch</button>
       <button id="connect-nodes">Connect Boxes</button>
       <div style="margin-top:10px;">
         <input id="jurisdiction-input" list="jurisdictions" placeholder="Select jurisdiction" />


### PR DESCRIPTION
## Summary
- allow ChartPal page to use the full screen width and increase canvas height
- reduce controls panel width and ensure editor pane has minimum width
- add ability to insert small circular "branch" nodes

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6880c2ef70f0832fac0011c17bae74a3