### PR TITLE
Improve ChartPal zoom and controls

### DIFF
--- a/docs/assets/chartpal/chartpal.js
+++ b/docs/assets/chartpal/chartpal.js
@@ -360,6 +360,7 @@ function updateTreeView() {
     const pre = document.getElementById('tree-output-display');
     pre.textContent = generateTreeOutput(root);
     if (window.twemoji) twemoji.parse(pre);
+    updateCsvText();
 }
 
 // --- INITIALIZATION ---
@@ -614,29 +615,34 @@ function redrawLines() {
     });
 }
 
-// --- NEW: Function to export the visual chart to CSV ---
-function exportToCsv() {
+// --- NEW: Functions to keep CSV text in sync and to export ---
+function generateCsvText() {
     const headers = "id,parent_id,name,ownership%,jurisdiction";
     let csvContent = [headers];
 
-    // The buildHierarchy function already gives us a flat list with parent_id
-    // We can just iterate through our 'chartNodes' map
     chartNodes.forEach(node => {
         const row = [
             node.id,
             node.parent_id || '0',
-            `"${node.name}"`, // Quote names to handle commas
+            `\"${node.name}\"`,
             node.ownership || '',
             node.jurisdiction || ''
         ].join(',');
         csvContent.push(row);
     });
+    return csvContent.join('\n');
+}
 
-    // Update the textarea and provide a download link
-    const csvText = csvContent.join('\n');
+function updateCsvText() {
+    const csvText = generateCsvText();
+    const area = document.getElementById('csvtext');
+    if (area) area.value = csvText;
+}
+
+function exportToCsv() {
+    const csvText = generateCsvText();
     document.getElementById('csvtext').value = csvText;
-    
-    // Trigger download
+
     const blob = new Blob([csvText], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -667,6 +673,39 @@ function importJson(evt) {
     };
     reader.readAsText(file);
     evt.target.value = '';
+}
+
+function saveVersion() {
+    const nameInput = document.getElementById('version-name');
+    if (!nameInput) return;
+    const name = nameInput.value.trim();
+    if (!name) return;
+    const data = JSON.stringify(Array.from(chartNodes.values()));
+    localStorage.setItem('chartpal-version-' + name, data);
+    updateVersionList();
+    nameInput.value = '';
+}
+
+function loadVersion(name) {
+    const data = localStorage.getItem('chartpal-version-' + name);
+    if (!data) return;
+    const records = JSON.parse(data);
+    drawChartFromData(records);
+}
+
+function updateVersionList() {
+    const select = document.getElementById('version-list');
+    if (!select) return;
+    select.innerHTML = '';
+    Object.keys(localStorage).forEach(k => {
+        if (k.startsWith('chartpal-version-')) {
+            const name = k.replace('chartpal-version-','');
+            const opt = document.createElement('option');
+            opt.value = name;
+            opt.textContent = name;
+            select.appendChild(opt);
+        }
+    });
 }
 
 function exportImage(type) {
@@ -866,8 +905,8 @@ function layoutGrid() {
     redrawLines();
 }
 
-function zoomCanvas(delta) {
-    canvasScale = Math.max(0.2, Math.min(3, canvasScale + delta));
+function setZoom(percent) {
+    canvasScale = Math.max(20, Math.min(300, percent)) / 100;
     document.getElementById('canvas').style.transform = `scale(${canvasScale})`;
     chartLines.forEach(line => {
         line.position();
@@ -875,8 +914,13 @@ function zoomCanvas(delta) {
             line.middleLabel.style.transform = `scale(${1 / canvasScale})`;
         }
     });
-    const disp = document.getElementById('zoom-display');
-    if (disp) disp.textContent = Math.round(canvasScale * 100) + '%';
+    const input = document.getElementById('zoom-input');
+    if (input) input.value = Math.round(canvasScale * 100);
+    redrawLines();
+}
+
+function zoomCanvas(delta) {
+    setZoom(canvasScale * 100 + delta * 100);
 }
 
 function initCanvasPan() {
@@ -934,6 +978,19 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('change-ownership').addEventListener('click', handleChangeOwnership);
     document.getElementById('zoom-in').addEventListener('click', () => zoomCanvas(0.1));
     document.getElementById('zoom-out').addEventListener('click', () => zoomCanvas(-0.1));
+    const zoomInput = document.getElementById('zoom-input');
+    if (zoomInput) {
+        zoomInput.addEventListener('change', () => {
+            const val = parseFloat(zoomInput.value);
+            if (!isNaN(val)) setZoom(val);
+        });
+    }
+    document.getElementById('save-version').addEventListener('click', saveVersion);
+    document.getElementById('load-version-btn').addEventListener('click', () => {
+        const sel = document.getElementById('version-list');
+        if (sel && sel.value) loadVersion(sel.value);
+    });
+    updateVersionList();
     document.getElementById('layout-grid').addEventListener('click', layoutGrid);
     initCanvasPan();
 

--- a/docs/assets/chartpal/style.css
+++ b/docs/assets/chartpal/style.css
@@ -75,16 +75,34 @@
 }
 
 .branch-node {
-    width: 40px;
+    width: 60px;
     height: 40px;
-    min-width: 40px;
+    min-width: 60px;
     min-height: 40px;
-    border-radius: 50%;
+    border-radius: 20px;
     line-height: 40px;
     padding: 0;
+    background-color: #eee;
 }
 
 .legend {
     margin-top: 5px;
     font-size: 0.9em;
+}
+
+.io-controls {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid #ccc;
+}
+.io-controls button {
+    display: block;
+    margin-top: 5px;
+}
+
+.version-controls input,
+.version-controls select,
+.version-controls button {
+    margin-top: 5px;
+    width: 100%;
 }

--- a/docs/chartpal.html
+++ b/docs/chartpal.html
@@ -34,7 +34,7 @@
       <h2>Controls</h2>
       <button id="add-node">Add Company Box</button>
       <button id="add-branch">Add Branch</button>
-      <button id="connect-nodes">Connect Boxes</button>
+      <button id="connect-nodes">Connect Nodes</button>
       <div style="margin-top:10px;">
         <input id="jurisdiction-input" list="jurisdictions" placeholder="Select jurisdiction" />
         <datalist id="jurisdictions"></datalist>
@@ -48,12 +48,14 @@
         <input id="ownership-input" placeholder="Ownership %" />
         <button id="change-ownership">Set Ownership</button>
       </div>
-      <button id="export-csv">Export to CSV</button>
-      <button id="export-png">Export PNG</button>
-      <button id="export-svg">Export SVG</button>
-      <button id="save-json">Save JSON</button>
-      <input type="file" id="jsonfile" accept=".json" style="display:none;" />
-      <button id="load-json">Load JSON</button>
+      <div class="io-controls" style="margin-top:10px;">
+        <button id="export-csv">Export CSV</button>
+        <button id="export-png">Export PNG</button>
+        <button id="export-svg">Export SVG</button>
+        <button id="save-json">Save JSON</button>
+        <input type="file" id="jsonfile" accept=".json" style="display:none;" />
+        <button id="load-json">Load JSON</button>
+      </div>
       <button id="undo-action">Undo</button>
       <button id="redo-action">Redo</button>
       <button id="delete-node">Delete Selected</button>
@@ -61,9 +63,15 @@
       <div style="margin-top:10px;">
         <button id="zoom-in">Zoom In</button>
         <button id="zoom-out">Zoom Out</button>
-        <span id="zoom-display">100%</span>
+        <input id="zoom-input" type="number" min="20" max="300" value="100" style="width:60px;">%
       </div>
       <button id="layout-grid">Grid Layout</button>
+      <div class="version-controls" style="margin-top:10px;">
+        <input id="version-name" placeholder="Version name" />
+        <button id="save-version">Save Version</button>
+        <select id="version-list"></select>
+        <button id="load-version-btn">Load Version</button>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- make branch nodes oval with grey background
- rename Connect button and reorganise export controls
- add editable zoom box and version save/load controls
- keep CSV textarea in sync with tree view
- reposition lines properly when zooming

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6880cdd7f3f8832f8c7c556abd0bea07