### PR TITLE
Improve ChartPal layout and controls

### DIFF
--- a/docs/assets/chartpal/chartpal.js
+++ b/docs/assets/chartpal/chartpal.js
@@ -805,6 +805,7 @@ function handleAddBranch() {
         parent_id: '0',
         name: `Branch ${newId}`,
         isBranch: true,
+        ownership: 100,
         children: []
     };
     renderNode(newNodeData, 50, 50);
@@ -890,16 +891,16 @@ function layoutGrid() {
             el.style.left = `${x}px`;
             el.style.top = `${y}px`;
         }
-        let childY = y + 150;
+        let childY = y + 200;
         node.children.forEach(child => {
             positionNode(child, x + 200, childY);
-            childY += 150;
+            childY += 200;
         });
     }
 
     hierarchy.children.forEach(node => {
         positionNode(node, 30, startY);
-        startY += 150;
+        startY += 200;
     });
 
     redrawLines();
@@ -960,11 +961,6 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('export-csv').addEventListener('click', exportToCsv);
     document.getElementById('export-png').addEventListener('click', () => exportImage('png'));
     document.getElementById('export-svg').addEventListener('click', () => exportImage('svg'));
-    document.getElementById('save-json').addEventListener('click', exportJson);
-    document.getElementById('load-json').addEventListener('click', () => {
-        document.getElementById('jsonfile').click();
-    });
-    document.getElementById('jsonfile').addEventListener('change', importJson);
     document.getElementById('undo-action').addEventListener('click', undo);
     document.getElementById('redo-action').addEventListener('click', redo);
     document.getElementById('delete-node').addEventListener('click', handleDeleteSelected);

--- a/docs/assets/chartpal/style.css
+++ b/docs/assets/chartpal/style.css
@@ -75,12 +75,12 @@
 }
 
 .branch-node {
-    width: 60px;
-    height: 40px;
-    min-width: 60px;
-    min-height: 40px;
-    border-radius: 20px;
-    line-height: 40px;
+    width: 150px;
+    height: 60px;
+    min-width: 150px;
+    min-height: 60px;
+    border-radius: 30px;
+    line-height: 60px;
     padding: 0;
     background-color: #eee;
 }
@@ -94,10 +94,17 @@
     margin-top: 10px;
     padding-top: 10px;
     border-top: 1px solid #ccc;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
 }
 .io-controls button {
-    display: block;
-    margin-top: 5px;
+    margin-top: 0;
+}
+
+#zoom-input {
+    width: 80px;
+    font-size: 0.9em;
 }
 
 .version-controls input,

--- a/docs/chartpal.html
+++ b/docs/chartpal.html
@@ -32,7 +32,7 @@
     </div>
     <div class="controls-pane">
       <h2>Controls</h2>
-      <button id="add-node">Add Company Box</button>
+      <button id="add-node">Add Entity</button>
       <button id="add-branch">Add Branch</button>
       <button id="connect-nodes">Connect Nodes</button>
       <div style="margin-top:10px;">
@@ -52,9 +52,6 @@
         <button id="export-csv">Export CSV</button>
         <button id="export-png">Export PNG</button>
         <button id="export-svg">Export SVG</button>
-        <button id="save-json">Save JSON</button>
-        <input type="file" id="jsonfile" accept=".json" style="display:none;" />
-        <button id="load-json">Load JSON</button>
       </div>
       <button id="undo-action">Undo</button>
       <button id="redo-action">Redo</button>
@@ -63,7 +60,7 @@
       <div style="margin-top:10px;">
         <button id="zoom-in">Zoom In</button>
         <button id="zoom-out">Zoom Out</button>
-        <input id="zoom-input" type="number" min="20" max="300" value="100" style="width:60px;">%
+        <input id="zoom-input" type="number" min="20" max="300" value="100" style="width:80px;font-size:0.9em;">%
       </div>
       <button id="layout-grid">Grid Layout</button>
       <div class="version-controls" style="margin-top:10px;">


### PR DESCRIPTION
## Summary
- remove JSON load/save buttons and update listeners
- rename "Add Company Box" control to "Add Entity"
- widen zoom input and reduce font
- line up export buttons and enlarge branch ovals
- increase grid layout spacing
- set branch ownership to 100%

## Testing
- `python -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_b_6880d16ee858832fa7c1bcc62f86185a