### PR TITLE
Improve Sankey builder usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ This repository contains a small static website with several tools:
 
 The site is contained entirely in the `docs/` directory and can be used locally or hosted on any static web server.
 
+## Sankey Diagram Generator
+
+The generator accepts data in CSV format using `source,target,value` columns or
+as a JSON array of objects with those keys. Data can be entered directly in the
+text box or by dragging a `.csv` or `.json` file onto the drop zone, which will
+render the chart automatically. Colour pickers and a font size input let you
+style the nodes and links, while orientation, width and height controls allow
+further layout customisation. Use the export buttons to download the data as CSV
+or JSON or save the diagram as a PNG image.
+
 ## Usage
 
 No build step is required. Open `docs/index.html` in a web browser. From there you can navigate to:

--- a/docs/assets/sankey/sankey.js
+++ b/docs/assets/sankey/sankey.js
@@ -9,6 +9,9 @@ document.addEventListener('DOMContentLoaded', function () {
   const nodeColorInput = document.getElementById('nodeColor');
   const linkColorInput = document.getElementById('linkColor');
   const fontSizeInput = document.getElementById('fontSize');
+  const orientationInput = document.getElementById('orientation');
+  const widthInput = document.getElementById('chartWidth');
+  const heightInput = document.getElementById('chartHeight');
   const exportCsvBtn = document.getElementById('export-csv');
   const exportJsonBtn = document.getElementById('export-json');
   const exportPngBtn = document.getElementById('export-png');
@@ -74,8 +77,13 @@ document.addEventListener('DOMContentLoaded', function () {
     const rows = [['From', 'To', 'Weight']];
     data.forEach(d => rows.push([d.source, d.target, d.value]));
     const dataTable = google.visualization.arrayToDataTable(rows);
+    chartDiv.style.width = widthInput.value ? widthInput.value + 'px' : '';
+    chartDiv.style.height = heightInput.value ? heightInput.value + 'px' : '';
     const options = {
+      width: widthInput.value ? parseInt(widthInput.value, 10) : undefined,
+      height: heightInput.value ? parseInt(heightInput.value, 10) : undefined,
       sankey: {
+        orientation: orientationInput.value === 'vertical' ? 'vertical' : 'horizontal',
         node: {
           color: nodeColorInput.value,
           label: { fontSize: parseInt(fontSizeInput.value, 10) || 12 }
@@ -99,7 +107,19 @@ document.addEventListener('DOMContentLoaded', function () {
     const file = e.dataTransfer.files[0];
     if (!file) return;
     const reader = new FileReader();
-    reader.onload = () => { textarea.value = reader.result.trim(); };
+    reader.onload = () => {
+      textarea.value = reader.result.trim();
+      const { data, error } = parseInput(textarea.value);
+      if (error) { showError(error); return; }
+      const issues = validateData(data);
+      if (issues.length) {
+        showError('Flow mismatch at nodes: ' + issues.join(', '));
+        return;
+      }
+      clearError();
+      chartData = data;
+      drawChart(chartData);
+    };
     reader.readAsText(file);
   });
 

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -68,27 +68,6 @@ input {
   border-color: #007bff; /* Added: Better visual feedback */
 }
 
-/* Full-page drop zone - Fixed conflicts with body max-width */
-.page-drop {
-  position: fixed; /* Fixed: Use fixed positioning instead of conflicting width rules */
-  top: 0;
-  left: 0;
-  width: 100vw; /* Use viewport width instead of 100% */
-  height: 100vh; /* Use viewport height */
-  margin: 0;
-  padding: 20px;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  background: #f9f9f9; /* Match body background */
-  z-index: 1000; /* Ensure it appears above other content */
-}
-
-.page-drop.drag {
-  background: #eef;
-}
 
 .example {
   background: #f0f0f0;

--- a/docs/sankey.html
+++ b/docs/sankey.html
@@ -29,6 +29,14 @@ Gross Profit,Net Profit,200</pre>
     <label>Node Color: <input type="color" id="nodeColor" value="#a6cee3"></label>
     <label>Link Color: <input type="color" id="linkColor" value="#1f78b4"></label>
     <label>Font Size: <input type="number" id="fontSize" value="12" style="width:60px;"></label>
+    <label>Orientation:
+      <select id="orientation">
+        <option value="horizontal">Horizontal</option>
+        <option value="vertical">Vertical</option>
+      </select>
+    </label>
+    <label>Width: <input type="number" id="chartWidth" style="width:80px;" placeholder="auto"></label>
+    <label>Height: <input type="number" id="chartHeight" style="width:80px;" placeholder="auto"></label>
   </div>
   <button id="render-btn">Render</button>
   <div id="error" style="color:red;margin-top:10px;"></div>


### PR DESCRIPTION
## Summary
- auto-render chart when files are dropped on the Sankey page
- allow setting orientation, width and height of the Sankey chart
- remove unused `.page-drop` CSS
- document how to use the Sankey Diagram Generator in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6888b7a3717c832fbe48c51c0a4f1c5b