### PR TITLE
Improve chart layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This repository contains a small static website with several tools:
 4. **Side‑by‑Side Viewer** – display the NACE and NAICS finders together for easy comparison.
 5. **Sankey Diagram Generator** – create simple Sankey diagrams from CSV/JSON data.
 6. **ChartPal** – A client-side organisational chart builder written in vanilla JavaScript.
-   The tool now supports undo/redo history, local saves, PNG/SVG export and
+   The diagram uses a top‑down orientation with connections drawn from the bottom
+   of a parent box to the top of its children. The tool supports undo/redo history, local saves, PNG/SVG export and
    keyboard shortcuts. Hold <kbd>Shift</kbd> or <kbd>Ctrl</kbd> when clicking to
    select multiple nodes. Useful shortcuts include:
    <kbd>N</kbd> to add a node, <kbd>B</kbd> for a branch, <kbd>C</kbd> to connect,

--- a/docs/assets/chartpal/chartpal.js
+++ b/docs/assets/chartpal/chartpal.js
@@ -430,8 +430,8 @@ function drawChartFromData(records) {
             color: '#007bff',
             size: 2,
             path: 'grid',
-            startSocket: 'right',
-            endSocket: 'left',
+            startSocket: 'bottom',
+            endSocket: 'top',
             middleLabel: label
         };
         if (node.ownership && node.ownership < 100) {
@@ -620,8 +620,8 @@ function redrawLines() {
                 color: '#007bff',
                 size: 2,
                 path: 'grid',
-                startSocket: 'right',
-                endSocket: 'left',
+                startSocket: 'bottom',
+                endSocket: 'top',
                 middleLabel: label
             };
             if (node.ownership && node.ownership < 100) {
@@ -960,30 +960,30 @@ function toggleConnectMode() {
 function layoutGrid(spacingX = 200, spacingY = 200) {
     const hierarchy = buildHierarchy(Array.from(chartNodes.values()));
 
-    function calcHeight(node) {
-        if (!node.children.length) { node._h = 1; return 1; }
-        node._h = node.children.map(c => calcHeight(c)).reduce((a,b)=>a+b,0);
-        return node._h;
+    function calcWidth(node) {
+        if (!node.children.length) { node._w = 1; return 1; }
+        node._w = node.children.map(c => calcWidth(c)).reduce((a,b)=>a+b,0);
+        return node._w;
     }
-    hierarchy.children.forEach(calcHeight);
+    hierarchy.children.forEach(calcWidth);
 
     function position(node, x, y) {
         const el = document.getElementById(`node-${safeId(node.id)}`);
         if (el) { el.style.left = `${x}px`; el.style.top = `${y}px`; }
-        let childY = y - (node._h * spacingY - spacingY) / 2;
-        const childX = x + spacingX;
+        let childX = x - (node._w * spacingX - spacingX) / 2;
+        const childY = y + spacingY;
         node.children.forEach(c => {
-            const height = c._h * spacingY;
-            position(c, childX, childY + height / 2);
-            childY += height;
+            const width = c._w * spacingX;
+            position(c, childX + width / 2, childY);
+            childX += width;
         });
     }
 
-    let startY = 30;
-    const startX = 30;
+    let startX = 30;
+    const startY = 30;
     hierarchy.children.forEach(c => {
-        position(c, startX, startY + (c._h * spacingY) / 2);
-        startY += c._h * spacingY + spacingY;
+        position(c, startX + (c._w * spacingX) / 2, startY);
+        startX += c._w * spacingX + spacingX;
     });
 
     redrawLines();

--- a/docs/assets/sankey/sankey.js
+++ b/docs/assets/sankey/sankey.js
@@ -77,11 +77,11 @@ document.addEventListener('DOMContentLoaded', function () {
     const rows = [['From', 'To', 'Weight']];
     data.forEach(d => rows.push([d.source, d.target, d.value]));
     const dataTable = google.visualization.arrayToDataTable(rows);
-    chartDiv.style.width = widthInput.value ? widthInput.value + 'px' : '';
-    chartDiv.style.height = heightInput.value ? heightInput.value + 'px' : '';
+    chartDiv.style.width = widthInput.value ? widthInput.value + 'px' : '100%';
+    chartDiv.style.height = heightInput.value ? heightInput.value + 'px' : '500px';
     const options = {
-      width: widthInput.value ? parseInt(widthInput.value, 10) : undefined,
-      height: heightInput.value ? parseInt(heightInput.value, 10) : undefined,
+      width: widthInput.value ? parseInt(widthInput.value, 10) : chartDiv.clientWidth,
+      height: heightInput.value ? parseInt(heightInput.value, 10) : parseInt(chartDiv.style.height, 10),
       sankey: {
         orientation: orientationInput.value === 'vertical' ? 'vertical' : 'horizontal',
         node: {

--- a/docs/sankey.html
+++ b/docs/sankey.html
@@ -40,7 +40,7 @@ Gross Profit,Net Profit,200</pre>
   </div>
   <button id="render-btn">Render</button>
   <div id="error" style="color:red;margin-top:10px;"></div>
-  <div id="chart" style="margin-top:20px;"></div>
+  <div id="chart" style="margin-top:20px;width:100%;height:500px;"></div>
   <div style="margin-top:20px;">
     <button id="export-csv">Export CSV</button>
     <button id="export-json">Export JSON</button>


### PR DESCRIPTION
## Summary
- ensure Sankey chart has reasonable default size
- clarify ChartPal top-down orientation in README
- connect ChartPal lines from parent bottom to child top
- update grid layout to place parents above children

## Testing
- `python -m py_compile scripts/extract_docx.py scripts/extract_tpg.py`

------
https://chatgpt.com/codex/tasks/task_b_6888c0d115f0832faa4643dfffa318ee