### PR TITLE
Refactor ChartPal parsing and layout with validation

### DIFF
--- a/docs/assets/chartpal/chartpal.js
+++ b/docs/assets/chartpal/chartpal.js
@@ -1,3 +1,5 @@
+import { parseCsvText, buildHierarchy } from "./parser.js";
+import { layoutGrid as layoutGridImpl } from "./layout.js";
 // ChartPal - ASCII/Unicode Organisational Chart Builder
 let countryNames = {};
 let currentCsvText = '';
@@ -143,58 +145,6 @@ function readXlsxFile(file) {
     });
 }
 
-function parseCsvText(text) {
-    // Use PapaParse for robust CSV parsing
-    const result = Papa.parse(text.trim(), { header: true, skipEmptyLines: true });
-    if (result.errors.length > 0) {
-        console.error("CSV Parsing Errors:", result.errors);
-        throw new Error(`CSV Error: ${result.errors[0].message} on row ${result.errors[0].row}.`);
-    }
-    return result.data.map(r => {
-        // normalise keys to lower case for robustness
-        const rec = {};
-        Object.entries(r).forEach(([k,v]) => rec[k.trim().toLowerCase()] = v);
-
-        // Ensure parent_id=0 for root nodes if missing
-        if (!rec.parent_id) rec.parent_id = '0';
-
-        // support both ownership% and ownership columns
-        let ownVal = rec['ownership%'] || rec['ownership'] || '';
-        if (ownVal !== '') {
-            ownVal = String(ownVal).trim().replace('%','');
-            if (!isNaN(ownVal)) rec.ownership = parseFloat(ownVal);
-        }
-
-        rec.id = rec.id || '';
-        return rec;
-    });
-}
-
-function buildHierarchy(records) {
-    const nodes = new Map();
-    records.forEach(rec => {
-        // Clean up ownership percentage
-        if (rec['ownership%'] !== undefined) {
-             let val = String(rec['ownership%']).trim().replace('%', '');
-             if (val !== '' && !isNaN(val)) {
-                rec.ownership = parseFloat(val);
-             }
-        }
-        const x = rec.x !== undefined ? parseFloat(rec.x) : undefined;
-        const y = rec.y !== undefined ? parseFloat(rec.y) : undefined;
-        nodes.set(rec.id, { ...rec, x, y, children: [] });
-    });
-    
-    const roots = [];
-    nodes.forEach(node => {
-        if (node.parent_id && nodes.has(node.parent_id)) {
-            nodes.get(node.parent_id).children.push(node);
-        } else {
-            roots.push(node);
-        }
-    });
-    return { children: roots };
-}
 
 // --- OUTPUT GENERATORS ---
 
@@ -473,11 +423,18 @@ function renderNode(nodeData, x, y) {
     } else {
         const flag = nodeData.jurisdiction ? countryFlagEmoji(nodeData.jurisdiction) : '';
         const jurName = getJurisdictionName(nodeData.jurisdiction);
-        nodeEl.innerHTML = `
-            <span class="flag">${flag}</span>
-            <div class="company-name">${nodeData.name || 'Unnamed'}</div>
-            <div class="jurisdiction">${jurName}</div>
-        `;
+                const flagEl = document.createElement('span');
+        flagEl.className = 'flag';
+        flagEl.textContent = flag;
+        const nameEl = document.createElement('div');
+        nameEl.className = 'company-name';
+        nameEl.textContent = nodeData.name || 'Unnamed';
+        const jurEl = document.createElement('div');
+        jurEl.className = 'jurisdiction';
+        jurEl.textContent = jurName;
+        nodeEl.appendChild(flagEl);
+        nodeEl.appendChild(nameEl);
+        nodeEl.appendChild(jurEl);
     }
 
     canvas.appendChild(nodeEl);
@@ -539,23 +496,22 @@ function renderNode(nodeData, x, y) {
 function makeDraggable(element) {
     let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
     let startPositions = new Map();
-    element.onmousedown = dragMouseDown;
-
-    function dragMouseDown(e) {
+    const dragPointerDown = (e) => {
         e.preventDefault();
+        if (element.setPointerCapture) element.setPointerCapture(e.pointerId);
         pos3 = e.clientX;
         pos4 = e.clientY;
-        document.onmouseup = closeDragElement;
-        document.onmousemove = elementDrag;
+        document.addEventListener('pointerup', closeDragElement);
+        document.addEventListener('pointermove', elementDrag);
         const ids = selectedNodeIds.size && selectedNodeIds.has(element.dataset.id) ? selectedNodeIds : new Set([element.dataset.id]);
         startPositions.clear();
         ids.forEach(id => {
             const el = document.getElementById(`node-${safeId(id)}`);
             startPositions.set(id, {x: el.offsetLeft, y: el.offsetTop});
         });
-    }
-
-    function elementDrag(e) {
+        element.style.cursor = 'grabbing';
+    };
+    const elementDrag = (e) => {
         e.preventDefault();
         pos1 = pos3 - e.clientX;
         pos2 = pos4 - e.clientY;
@@ -564,19 +520,18 @@ function makeDraggable(element) {
         const ids = selectedNodeIds.size && selectedNodeIds.has(element.dataset.id) ? selectedNodeIds : new Set([element.dataset.id]);
         ids.forEach(id => {
             const el = document.getElementById(`node-${safeId(id)}`);
-            el.style.top = (el.offsetTop - pos2) + "px";
-            el.style.left = (el.offsetLeft - pos1) + "px";
+            el.style.top = (el.offsetTop - pos2) + 'px';
+            el.style.left = (el.offsetLeft - pos1) + 'px';
             const node = chartNodes.get(id);
             node.x = el.offsetLeft;
             node.y = el.offsetTop;
         });
         chartLines.forEach(line => line.position());
         updateCanvasSize();
-    }
-
-    function closeDragElement() {
-        document.onmouseup = null;
-        document.onmousemove = null;
+    };
+    const closeDragElement = (e) => {
+        document.removeEventListener('pointerup', closeDragElement);
+        document.removeEventListener('pointermove', elementDrag);
         const ids = selectedNodeIds.size && selectedNodeIds.has(element.dataset.id) ? selectedNodeIds : new Set([element.dataset.id]);
         const moves = [];
         ids.forEach(id => {
@@ -585,7 +540,10 @@ function makeDraggable(element) {
             moves.push({id, fromX:start.x, fromY:start.y, toX:el.offsetLeft, toY:el.offsetTop});
         });
         if (moves.length) pushHistory({type:'move', moves});
-    }
+        element.style.cursor = 'grab';
+    };
+    element.addEventListener('pointerdown', dragPointerDown);
+    element.style.cursor = 'grab';
 }
 
 function removeNodeById(id) {
@@ -958,36 +916,9 @@ function toggleConnectMode() {
 }
 
 function layoutGrid(spacingX = 200, spacingY = 200) {
-    const hierarchy = buildHierarchy(Array.from(chartNodes.values()));
-
-    function calcWidth(node) {
-        if (!node.children.length) { node._w = 1; return 1; }
-        node._w = node.children.map(c => calcWidth(c)).reduce((a,b)=>a+b,0);
-        return node._w;
-    }
-    hierarchy.children.forEach(calcWidth);
-
-    function position(node, x, y) {
-        const el = document.getElementById(`node-${safeId(node.id)}`);
-        if (el) { el.style.left = `${x}px`; el.style.top = `${y}px`; }
-        let childX = x - (node._w * spacingX - spacingX) / 2;
-        const childY = y + spacingY;
-        node.children.forEach(c => {
-            const width = c._w * spacingX;
-            position(c, childX + width / 2, childY);
-            childX += width;
-        });
-    }
-
-    let startX = 30;
-    const startY = 30;
-    hierarchy.children.forEach(c => {
-        position(c, startX + (c._w * spacingX) / 2, startY);
-        startX += c._w * spacingX + spacingX;
-    });
-
-    redrawLines();
+    layoutGridImpl(chartNodes, safeId, redrawLines, spacingX, spacingY);
 }
+
 
 function setZoom(percent) {
     canvasScale = Math.max(20, Math.min(300, percent)) / 100;

--- a/docs/assets/chartpal/layout.js
+++ b/docs/assets/chartpal/layout.js
@@ -1,0 +1,29 @@
+import { buildHierarchy } from './parser.js';
+
+export function layoutGrid(chartNodes, safeId, redrawLines = () => {}, spacingX = 200, spacingY = 200) {
+  const hierarchy = buildHierarchy(Array.from(chartNodes.values()));
+  function calcWidth(node) {
+    if (!node.children.length) { node._w = 1; return 1; }
+    node._w = node.children.map(c => calcWidth(c)).reduce((a,b)=>a+b,0);
+    return node._w;
+  }
+  hierarchy.children.forEach(calcWidth);
+  function position(node, x, y) {
+    const el = typeof document !== 'undefined' ? document.getElementById(`node-${safeId(node.id)}`) : null;
+    if (el) { el.style.left = `${x}px`; el.style.top = `${y}px`; }
+    let childX = x - (node._w * spacingX - spacingX) / 2;
+    const childY = y + spacingY;
+    node.children.forEach(c => {
+      const width = c._w * spacingX;
+      position(c, childX + width / 2, childY);
+      childX += width;
+    });
+  }
+  let startX = 30;
+  const startY = 30;
+  hierarchy.children.forEach(c => {
+    position(c, startX + (c._w * spacingX) / 2, startY);
+    startX += c._w * spacingX + spacingX;
+  });
+  redrawLines();
+}

--- a/docs/assets/chartpal/parser.js
+++ b/docs/assets/chartpal/parser.js
@@ -1,0 +1,52 @@
+export function parseCsvText(text) {
+  const result = Papa.parse(text.trim(), { header: true, skipEmptyLines: true });
+  if (result.errors.length > 0) {
+    console.error('CSV Parsing Errors:', result.errors);
+    throw new Error(`CSV Error: ${result.errors[0].message} on row ${result.errors[0].row}.`);
+  }
+  return result.data.map((r, idx) => {
+    const rec = {};
+    Object.entries(r).forEach(([k, v]) => (rec[k.trim().toLowerCase()] = v));
+    if (!rec.parent_id) rec.parent_id = '0';
+    let ownVal = rec['ownership%'] || rec['ownership'] || '';
+    if (ownVal !== '') {
+      ownVal = String(ownVal).trim().replace('%', '');
+      if (!isNaN(ownVal)) rec.ownership = parseFloat(ownVal);
+    }
+    rec.id = rec.id || '';
+    if (String(rec.id).trim() === '') {
+      throw new Error(`CSV Error: Missing id on row ${idx + 2}`);
+    }
+    return rec;
+  });
+}
+
+export function buildHierarchy(records) {
+  const nodes = new Map();
+  records.forEach((rec, idx) => {
+    if (!rec.id || String(rec.id).trim() === '') {
+      throw new Error(`Record at index ${idx} missing id`);
+    }
+    if (nodes.has(rec.id)) {
+      throw new Error(`Duplicate id '${rec.id}' detected`);
+    }
+    if (rec['ownership%'] !== undefined) {
+      let val = String(rec['ownership%']).trim().replace('%', '');
+      if (val !== '' && !isNaN(val)) {
+        rec.ownership = parseFloat(val);
+      }
+    }
+    const x = rec.x !== undefined ? parseFloat(rec.x) : undefined;
+    const y = rec.y !== undefined ? parseFloat(rec.y) : undefined;
+    nodes.set(rec.id, { ...rec, x, y, children: [] });
+  });
+  const roots = [];
+  nodes.forEach(node => {
+    if (node.parent_id && nodes.has(node.parent_id)) {
+      nodes.get(node.parent_id).children.push(node);
+    } else {
+      roots.push(node);
+    }
+  });
+  return { children: roots };
+}

--- a/docs/chartpal.html
+++ b/docs/chartpal.html
@@ -95,6 +95,6 @@
     <div id="error-box" class="error"></div>
   </div>
 
-  <script src="assets/chartpal/chartpal.js"></script>
+  <script type="module" src="assets/chartpal/chartpal.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "oecd-tpg-viewer-NACE-look-up",
+  "type": "module",
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "papaparse": "^5.4.1",
+    "jsdom": "^22.1.0"
+  },
+  "scripts": {
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand"
+  }
+}

--- a/tests/layout.test.js
+++ b/tests/layout.test.js
@@ -1,0 +1,16 @@
+import { JSDOM } from 'jsdom';
+import { layoutGrid } from '../docs/assets/chartpal/layout.js';
+
+test('layoutGrid positions nodes', () => {
+  const dom = new JSDOM(`<div id="chart"><div id="node-1"></div><div id="node-2"></div></div>`);
+  global.document = dom.window.document;
+  const chartNodes = new Map([
+    ['1', { id: '1', parent_id: '0', name: 'Root' }],
+    ['2', { id: '2', parent_id: '1', name: 'Child' }]
+  ]);
+  layoutGrid(chartNodes, id => id, () => {}, 100, 100);
+  const node1 = document.getElementById('node-1');
+  const node2 = document.getElementById('node-2');
+  expect(node1.style.left).not.toBe('');
+  expect(node2.style.top).not.toBe('');
+});

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -1,0 +1,16 @@
+import Papa from 'papaparse';
+global.Papa = Papa;
+import { parseCsvText, buildHierarchy } from '../docs/assets/chartpal/parser.js';
+
+test('parseCsvText throws on missing id', () => {
+  const csv = 'id,parent_id,name\n,0,Root';
+  expect(() => parseCsvText(csv)).toThrow(/Missing id/);
+});
+
+test('buildHierarchy throws on duplicate id', () => {
+  const records = [
+    { id: '1', parent_id: '0' },
+    { id: '1', parent_id: '0' }
+  ];
+  expect(() => buildHierarchy(records)).toThrow(/Duplicate id/);
+});


### PR DESCRIPTION
## Summary
- sanitize node rendering to prevent HTML injection
- validate CSV IDs and catch duplicates during hierarchy build
- add layout and parsing modules with basic Jest tests

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_b_689f8342ce3c832f8b31387682f69cf0