### PR TITLE
Add APA transfer pricing data loader and search

### DIFF
--- a/docs/assets/apa/apa-search.js
+++ b/docs/assets/apa/apa-search.js
@@ -1,0 +1,52 @@
+import fs from 'fs';
+import Papa from 'papaparse';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+export const APA_COLUMNS = [
+  'Documentnummer',
+  'Aantal transacties',
+  'Datum van publicatie',
+  'Start looptijd',
+  'Einde looptijd',
+  'Type verzoek',
+  'Vaste inrichting',
+  'Branche, industrie of sector',
+  'Partij 1',
+  'Partij 2',
+  "Functies, activa en risico's van partij 1",
+  "Functies, activa en risico's van partij 2",
+  'Transactie',
+  'Methode',
+  'Lower quartile',
+  'Upper quartile',
+  'Opmerking',
+  'Edge case?'
+];
+
+export function loadApaData(filePath) {
+  const ext = filePath.split('.').pop().toLowerCase();
+  if (ext === 'csv') {
+    const text = fs.readFileSync(filePath, 'utf8');
+    const result = Papa.parse(text, { header: true, skipEmptyLines: true });
+    return result.data;
+  } else if (ext === 'xlsx' || ext === 'xls') {
+    const XLSX = require('xlsx');
+    const workbook = XLSX.readFile(filePath);
+    const sheetName = workbook.SheetNames[0];
+    const sheet = workbook.Sheets[sheetName];
+    return XLSX.utils.sheet_to_json(sheet, { defval: '' });
+  }
+  throw new Error('Unsupported file type');
+}
+
+export function searchApaData(records, criteria) {
+  return records.filter(rec => {
+    return Object.entries(criteria).every(([key, value]) => {
+      if (!value) return true;
+      const field = rec[key];
+      return field && field.toString().toLowerCase().includes(String(value).toLowerCase());
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "devDependencies": {
     "jest": "^29.7.0",
     "papaparse": "^5.4.1",
-    "jsdom": "^22.1.0"
+    "jsdom": "^22.1.0",
+    "xlsx": "^0.18.5"
   },
   "scripts": {
     "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --runInBand"

--- a/tests/apa.test.js
+++ b/tests/apa.test.js
@@ -1,0 +1,17 @@
+import { loadApaData, searchApaData } from '../docs/assets/apa/apa-search.js';
+import path from 'path';
+
+const csvPath = path.join('tests', 'fixtures', 'apa_sample.csv');
+
+test('loadApaData reads CSV', () => {
+  const records = loadApaData(csvPath);
+  expect(records.length).toBe(2);
+  expect(records[0].Documentnummer).toBe('APA001');
+});
+
+test('searchApaData finds matching records', () => {
+  const records = loadApaData(csvPath);
+  const result = searchApaData(records, { 'Partij 1': 'Company A' });
+  expect(result.length).toBe(1);
+  expect(result[0].Documentnummer).toBe('APA001');
+});

--- a/tests/fixtures/apa_sample.csv
+++ b/tests/fixtures/apa_sample.csv
@@ -1,0 +1,3 @@
+Documentnummer,Aantal transacties,Datum van publicatie,Start looptijd,Einde looptijd,Type verzoek,Vaste inrichting,"Branche, industrie of sector",Partij 1,Partij 2,"Functies, activa en risico's van partij 1","Functies, activa en risico's van partij 2",Transactie,Methode,Lower quartile,Upper quartile,Opmerking,"Edge case?"
+APA001,2,2023-01-01,2023-01-01,2025-01-01,Type A,No,Manufacturing,Company A,Company B,Functions A,Functions B,Sale,CUP,100,200,Note 1,
+APA002,3,2023-02-01,2023-02-01,2024-02-01,Type B,Yes,Services,Company C,Company D,Functions C,Functions D,Service,COST+,150,250,Note 2,Yes


### PR DESCRIPTION
## Summary
- add module to load APA CSV/Excel data and search by transaction fields
- include sample dataset and tests verifying load and search functions
- register xlsx dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b9827f2630832f9bb5d0467ce6f43e